### PR TITLE
Add audit log decorator pattern and viewer endpoint

### DIFF
--- a/backend/core/audit_log.py
+++ b/backend/core/audit_log.py
@@ -1,0 +1,108 @@
+"""
+Admin audit log utility for VegaExchange.
+
+Uses a decorator pattern with AuditContext dependency:
+
+    @router.post("/create_symbol", response_model=APIResponse)
+    @audit_logged(action="create_symbol", target_type="symbol")
+    async def create_symbol(
+        ...,
+        current_admin: dict = Depends(require_admin),
+        audit: AuditContext = Depends(get_audit_context),
+    ):
+        ...
+        audit.set(target_id=str(result["symbol_id"]), details={...})
+        return APIResponse(...)
+
+The decorator automatically logs the action after successful execution.
+Audit logging failures are caught — they must never break the main operation.
+"""
+
+import inspect
+import json
+import traceback
+from functools import wraps
+from typing import Optional
+
+from backend.core.db_manager import get_db
+
+
+class AuditContext:
+    """Mutable context that an endpoint populates with audit metadata."""
+
+    def __init__(self):
+        self.target_id: Optional[str] = None
+        self.details: Optional[dict] = None
+
+    def set(self, target_id: str, details: Optional[dict] = None) -> None:
+        self.target_id = target_id
+        self.details = details
+
+
+def get_audit_context() -> AuditContext:
+    """FastAPI dependency that provides a fresh AuditContext per request."""
+    return AuditContext()
+
+
+async def _write_audit_log(
+    admin_id: str,
+    action: str,
+    target_type: str,
+    target_id: str,
+    details: Optional[dict] = None,
+) -> None:
+    """Insert a row into admin_audit_logs. Never raises."""
+    try:
+        db = get_db()
+        details_json = json.dumps(details) if details else None
+        await db.execute(
+            """
+            INSERT INTO admin_audit_logs (admin_id, action, target_type, target_id, details)
+            VALUES ($1, $2, $3, $4, $5::jsonb)
+            """,
+            admin_id,
+            action,
+            target_type,
+            target_id,
+            details_json,
+        )
+    except Exception:
+        print(f"[WARN] Failed to log admin action: {action} by {admin_id}")
+        traceback.print_exc()
+
+
+def audit_logged(action: str, target_type: str):
+    """
+    Decorator that logs admin actions after successful endpoint execution.
+
+    The decorated endpoint must have these keyword arguments:
+    - current_admin: dict  (from Depends(require_admin))
+    - audit: AuditContext   (from Depends(get_audit_context))
+
+    The endpoint calls audit.set(target_id=..., details=...) before returning.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            response = await func(*args, **kwargs)
+
+            current_admin = kwargs.get("current_admin")
+            audit: Optional[AuditContext] = kwargs.get("audit")
+
+            if current_admin and audit and audit.target_id is not None:
+                await _write_audit_log(
+                    admin_id=current_admin["admin_id"],
+                    action=action,
+                    target_type=target_type,
+                    target_id=audit.target_id,
+                    details=audit.details,
+                )
+
+            return response
+
+        # Preserve original function signature so FastAPI can inspect parameters
+        wrapper.__signature__ = inspect.signature(func)
+        return wrapper
+
+    return decorator

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -7,9 +7,11 @@ All endpoints require admin permissions.
 import json
 from decimal import Decimal
 from math import sqrt
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from backend.core.audit_log import AuditContext, audit_logged, get_audit_context
 from backend.core.auth import require_admin
 from backend.core.dependencies import get_router
 from backend.core.db_manager import get_db
@@ -22,11 +24,17 @@ from backend.models.responses import APIResponse
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
 
+# =============================================================================
+# Symbol Management
+# =============================================================================
+
 @router.post("/create_symbol", response_model=APIResponse)
+@audit_logged(action="create_symbol", target_type="symbol")
 async def create_symbol(
     request: CreateSymbolRequest,
     router: EngineRouter = Depends(get_router),
     current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
 ):
     """
     Create a new trading symbol (CLOB only).
@@ -41,11 +49,10 @@ async def create_symbol(
     if request.engine_type != EngineType.CLOB:
         raise HTTPException(
             status_code=400,
-            detail=f"Only CLOB symbols can be created manually. Use /create_pool endpoint for AMM symbols."
+            detail="Only CLOB symbols can be created manually. Use /create_pool endpoint for AMM symbols."
         )
 
     # Check if symbol + engine_type combination already exists
-    # (Same symbol can exist with different engine types for arbitrage)
     existing = await db.read_one(
         "SELECT symbol_id FROM symbol_configs WHERE symbol = $1 AND engine_type = $2",
         request.symbol,
@@ -53,17 +60,13 @@ async def create_symbol(
     )
     if existing:
         raise HTTPException(
-            status_code=400, 
+            status_code=400,
             detail=f"Symbol '{request.symbol}' with engine_type CLOB already exists"
         )
 
-    # Ensure settle is set (defaults to quote_asset)
     settle_asset = request.settle if request.settle else request.quote_asset
-    
-    # Convert engine_params dict to JSON string for JSONB column
     engine_params_json = json.dumps(request.engine_params) if request.engine_params else "{}"
-    
-    # Create symbol config (SERIAL id is auto-generated)
+
     result = await db.execute_returning(
         """
         INSERT INTO symbol_configs (
@@ -79,7 +82,7 @@ async def create_symbol(
         request.quote_asset,
         settle_asset,
         request.engine_type.value,
-        True,  # is_active
+        True,
         engine_params_json,
         request.min_trade_amount,
         request.max_trade_amount,
@@ -87,17 +90,23 @@ async def create_symbol(
         request.quantity_precision,
     )
 
-    # Invalidate cache
     router.invalidate_cache(request.symbol)
+
+    audit.set(
+        target_id=str(result["symbol_id"]),
+        details={"symbol": request.symbol, "engine_type": request.engine_type.value},
+    )
 
     return APIResponse(success=True, data=result)
 
 
 @router.post("/create_pool", response_model=APIResponse)
+@audit_logged(action="create_pool", target_type="pool")
 async def create_pool(
     request: CreatePoolRequest,
     router: EngineRouter = Depends(get_router),
     current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
 ):
     """
     Create a new AMM pool (auto-creates symbol).
@@ -108,8 +117,6 @@ async def create_pool(
     """
     db = get_db()
 
-    # Check if symbol + engine_type (AMM) combination already exists
-    # (Same symbol can exist with different engine types for arbitrage)
     existing = await db.read_one(
         "SELECT symbol_id FROM symbol_configs WHERE symbol = $1 AND engine_type = $2",
         request.symbol,
@@ -117,22 +124,19 @@ async def create_pool(
     )
     if existing:
         raise HTTPException(
-            status_code=400, 
+            status_code=400,
             detail=f"Symbol '{request.symbol}' with engine_type AMM already exists"
         )
 
-    # Ensure settle is set (defaults to quote_asset)
     settle_asset = request.settle if request.settle else request.quote_asset
-    
-    # Build engine_params from pool parameters
+
     engine_params = {
         "initial_reserve_base": float(request.initial_reserve_base),
         "initial_reserve_quote": float(request.initial_reserve_quote),
         "fee_rate": float(request.fee_rate),
     }
     engine_params_json = json.dumps(engine_params)
-    
-    # Create symbol config with AMM engine type (SERIAL id is auto-generated)
+
     symbol_result = await db.execute_returning(
         """
         INSERT INTO symbol_configs (
@@ -147,8 +151,8 @@ async def create_pool(
         request.base_asset,
         request.quote_asset,
         settle_asset,
-        EngineType.AMM.value,  # Always AMM for pools
-        True,  # is_active
+        EngineType.AMM.value,
+        True,
         engine_params_json,
         request.min_trade_amount,
         request.max_trade_amount,
@@ -156,19 +160,10 @@ async def create_pool(
         request.quantity_precision,
     )
 
-    # Generate pool ID
     pool_id = generate_pool_id()
-    
-    # Calculate initial k_value
     k_value = request.initial_reserve_base * request.initial_reserve_quote
-    
-    # Calculate protocol LP shares (geometric mean of initial reserves)
     protocol_lp_shares = Decimal(str(sqrt(float(request.initial_reserve_base * request.initial_reserve_quote))))
-    
-    # Create AMM pool with protocol LP shares
-    # Note: Protocol shares are implicitly tracked as:
-    #   protocol_shares = total_lp_shares - sum(all user lp_shares in lp_positions)
-    # This avoids needing a fake "PROTOCOL" user in the users table
+
     pool_result = await db.execute_returning(
         """
         INSERT INTO amm_pools (
@@ -186,8 +181,16 @@ async def create_pool(
         protocol_lp_shares,
     )
 
-    # Invalidate cache
     router.invalidate_cache(request.symbol)
+
+    audit.set(
+        target_id=pool_id,
+        details={
+            "symbol": request.symbol,
+            "symbol_id": symbol_result["symbol_id"],
+            "fee_rate": float(request.fee_rate),
+        },
+    )
 
     return APIResponse(
         success=True,
@@ -200,11 +203,13 @@ async def create_pool(
 
 
 @router.post("/update_symbol_status/{symbol}", response_model=APIResponse)
+@audit_logged(action="update_symbol_status", target_type="symbol")
 async def update_symbol_status(
     symbol: str,
     status: SymbolStatus = Query(..., description="Symbol status (ACTIVE or MAINTENANCE)"),
     router: EngineRouter = Depends(get_router),
     current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
 ):
     """
     Update symbol trading status.
@@ -214,9 +219,8 @@ async def update_symbol_status(
     """
     db = get_db()
 
-    # Convert SymbolStatus to boolean
     is_active = status == SymbolStatus.ACTIVE
-    
+
     result = await db.execute(
         """
         UPDATE symbol_configs
@@ -232,14 +236,21 @@ async def update_symbol_status(
 
     router.invalidate_cache(symbol.upper())
 
+    audit.set(
+        target_id=symbol.upper(),
+        details={"new_status": "active" if is_active else "maintenance"},
+    )
+
     return APIResponse(success=True, data={"symbol": symbol.upper(), "is_active": is_active})
 
 
 @router.post("/delete_symbol/{symbol}", response_model=APIResponse)
+@audit_logged(action="delete_symbol", target_type="symbol")
 async def delete_symbol(
     symbol: str,
     router: EngineRouter = Depends(get_router),
     current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
 ):
     """
     Delete a symbol (soft delete by setting status to maintenance).
@@ -263,4 +274,101 @@ async def delete_symbol(
 
     router.invalidate_cache(symbol.upper())
 
+    audit.set(target_id=symbol.upper())
+
     return APIResponse(success=True, data={"symbol": symbol.upper(), "deleted": True})
+
+
+# =============================================================================
+# Audit Log Viewer
+# =============================================================================
+
+@router.get("/audit-log", response_model=APIResponse)
+async def get_audit_log(
+    admin_id: Optional[str] = Query(None, description="Filter by admin ID"),
+    action: Optional[str] = Query(None, description="Filter by action type"),
+    target_type: Optional[str] = Query(None, description="Filter by target type"),
+    date_from: Optional[str] = Query(None, description="Start date (ISO format)"),
+    date_to: Optional[str] = Query(None, description="End date (ISO format)"),
+    limit: int = Query(50, ge=1, le=200, description="Page size"),
+    offset: int = Query(0, ge=0, description="Offset"),
+    current_admin: dict = Depends(require_admin),
+):
+    """
+    Query admin audit log with pagination and filters.
+
+    Returns log entries joined with admin name/email from the admins table.
+    """
+    db = get_db()
+
+    # Build dynamic WHERE clause
+    conditions = []
+    params = []
+    param_idx = 1
+
+    if admin_id:
+        conditions.append(f"aal.admin_id = ${param_idx}")
+        params.append(admin_id)
+        param_idx += 1
+
+    if action:
+        conditions.append(f"aal.action = ${param_idx}")
+        params.append(action)
+        param_idx += 1
+
+    if target_type:
+        conditions.append(f"aal.target_type = ${param_idx}")
+        params.append(target_type)
+        param_idx += 1
+
+    if date_from:
+        conditions.append(f"aal.created_at >= ${param_idx}::timestamptz")
+        params.append(date_from)
+        param_idx += 1
+
+    if date_to:
+        conditions.append(f"aal.created_at <= ${param_idx}::timestamptz")
+        params.append(date_to)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    # Count total
+    total = await db.read_one(
+        f"SELECT COUNT(*) as count FROM admin_audit_logs aal WHERE {where_clause}",
+        *params,
+    )
+
+    # Fetch page with admin info
+    logs = await db.read(
+        f"""
+        SELECT
+            aal.id,
+            aal.admin_id,
+            a.name as admin_name,
+            a.email as admin_email,
+            aal.action,
+            aal.target_type,
+            aal.target_id,
+            aal.details,
+            aal.created_at
+        FROM admin_audit_logs aal
+        JOIN admins a ON aal.admin_id = a.admin_id
+        WHERE {where_clause}
+        ORDER BY aal.created_at DESC
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """,
+        *params,
+        limit,
+        offset,
+    )
+
+    return APIResponse(
+        success=True,
+        data={
+            "logs": logs,
+            "total": total["count"] if total else 0,
+            "limit": limit,
+            "offset": offset,
+        },
+    )


### PR DESCRIPTION
## Summary
- Add decorator-based audit log system (`@audit_logged`) for tracking all admin operations
- Add `GET /api/admin/audit-log` endpoint with pagination and filters
- Integrate audit logging into all 4 existing admin endpoints

## Design

Uses a decorator pattern with `AuditContext` dependency:

```python
@router.post("/create_symbol", response_model=APIResponse)
@audit_logged(action="create_symbol", target_type="symbol")
async def create_symbol(
    ...,
    current_admin: dict = Depends(require_admin),
    audit: AuditContext = Depends(get_audit_context),
):
    # ... do work ...
    audit.set(target_id=str(result["symbol_id"]), details={...})
    return APIResponse(...)
```

The decorator automatically logs the action after successful execution. Failures in audit logging are caught and printed — they never break the main operation.

## Changes

### New files
- `backend/core/audit_log.py` — `AuditContext`, `@audit_logged` decorator, `_write_audit_log()`, `get_audit_context()` dependency

### New endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/admin/audit-log` | Query audit log with pagination + filters (admin_id, action, target_type, date_from, date_to) |

### Modified files
- `backend/routers/admin.py` — Applied `@audit_logged` decorator to `create_symbol`, `create_pool`, `update_symbol_status`, `delete_symbol`; added `audit-log` viewer endpoint

## Test plan
- [ ] Create a symbol → verify audit log entry appears with correct admin_id, action, target_id
- [ ] Create a pool → verify audit log entry
- [ ] Update symbol status → verify audit log with old/new status in details
- [ ] Delete symbol → verify audit log entry
- [ ] `GET /api/admin/audit-log` returns paginated results with admin name/email
- [ ] Filter by action, target_type, date range works
- [ ] Audit log failure does not break the main admin operation
- [ ] Endpoint requires admin auth

Closes #35
