### PR TITLE
Add dashboard stats, pool management, and user management endpoints

### DIFF
--- a/backend/models/admin.py
+++ b/backend/models/admin.py
@@ -34,6 +34,19 @@ class AddWhitelistRequest(BaseModel):
     description: Optional[str] = Field(None, description="Optional note about this admin")
 
 
+class UpdateUserBalanceRequest(BaseModel):
+    """Request to adjust a user's balance (absolute value)"""
+
+    currency: str = Field(..., description="Currency code (e.g., USDT)")
+    available: Decimal = Field(..., ge=0, description="New available balance value")
+
+
+class UpdateUserStatusRequest(BaseModel):
+    """Request to enable/disable a user account"""
+
+    is_active: bool = Field(..., description="Whether the user account should be active")
+
+
 class CreateSymbolRequest(BaseModel):
     """Request to create a new trading symbol"""
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -20,6 +20,8 @@ from backend.models.admin import (
     CreateSymbolRequest,
     UpdateSettingRequest,
     UpdateSymbolRequest,
+    UpdateUserBalanceRequest,
+    UpdateUserStatusRequest,
 )
 from backend.services import admin as admin_service
 
@@ -232,3 +234,132 @@ async def remove_whitelist(
         details={"email": result["email"]},
     )
     return APIResponse(success=True, data=result)
+
+
+# =============================================================================
+# Pool Management (#32)
+# =============================================================================
+
+@router.get("/pools", response_model=APIResponse)
+async def get_admin_pools(current_admin: dict = Depends(require_admin)):
+    """Get all AMM pools with enriched data (TVL, price, volume)."""
+    data = await admin_service.get_admin_pools()
+    return APIResponse(success=True, data=data)
+
+
+@router.get("/pools/{pool_id}", response_model=APIResponse)
+async def get_admin_pool(
+    pool_id: str,
+    current_admin: dict = Depends(require_admin),
+):
+    """Get detailed pool info + LP positions + recent swaps."""
+    data = await admin_service.get_admin_pool(pool_id)
+    return APIResponse(success=True, data=data)
+
+
+# =============================================================================
+# User Management (#33)
+# =============================================================================
+
+@router.get("/users", response_model=APIResponse)
+async def get_admin_users(
+    search: Optional[str] = Query(None, description="Search by email or username"),
+    is_active: Optional[bool] = Query(None, description="Filter by active status"),
+    limit: int = Query(20, ge=1, le=100, description="Page size"),
+    offset: int = Query(0, ge=0, description="Offset"),
+    sort_by: str = Query("created_at", description="Sort field"),
+    sort_order: str = Query("desc", description="Sort order: asc or desc"),
+    current_admin: dict = Depends(require_admin),
+):
+    """Get paginated user list with summary info."""
+    data = await admin_service.get_admin_users(
+        search=search, is_active=is_active,
+        limit=limit, offset=offset,
+        sort_by=sort_by, sort_order=sort_order,
+    )
+    return APIResponse(success=True, data=data)
+
+
+@router.get("/users/{user_id}", response_model=APIResponse)
+async def get_admin_user(
+    user_id: str,
+    current_admin: dict = Depends(require_admin),
+):
+    """Get full user profile + balances + recent trades."""
+    data = await admin_service.get_admin_user(user_id)
+    return APIResponse(success=True, data=data)
+
+
+@router.post("/users/{user_id}/balance/update", response_model=APIResponse)
+@audit_logged(action="update_user_balance", target_type="user")
+async def update_user_balance(
+    user_id: str,
+    request: UpdateUserBalanceRequest,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Adjust a user's balance (absolute value)."""
+    result = await admin_service.update_user_balance(user_id, request.currency, request.available)
+    audit.set(
+        target_id=user_id,
+        details={
+            "currency": result["currency"],
+            "old": float(result["old_available"]),
+            "new": float(result["new_available"]),
+        },
+    )
+    return APIResponse(success=True, data=result)
+
+
+@router.post("/users/{user_id}/status/update", response_model=APIResponse)
+@audit_logged(action="update_user_status", target_type="user")
+async def update_user_status(
+    user_id: str,
+    request: UpdateUserStatusRequest,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Enable/disable a user account. Revokes tokens when disabling."""
+    result = await admin_service.update_user_status(user_id, request.is_active)
+    audit.set(
+        target_id=user_id,
+        details={"is_active": request.is_active, "tokens_revoked": result["tokens_revoked"]},
+    )
+    return APIResponse(success=True, data=result)
+
+
+@router.post("/users/{user_id}/reset-balances", response_model=APIResponse)
+@audit_logged(action="reset_user_balances", target_type="user")
+async def reset_user_balances(
+    user_id: str,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Reset user balances to platform defaults."""
+    result = await admin_service.reset_user_balances(user_id)
+    audit.set(
+        target_id=user_id,
+        details={"reset_to": result["reset_to"]},
+    )
+    return APIResponse(success=True, data=result)
+
+
+# =============================================================================
+# Dashboard Stats (#30)
+# =============================================================================
+
+@router.get("/dashboard/stats", response_model=APIResponse)
+async def get_dashboard_stats(current_admin: dict = Depends(require_admin)):
+    """Get aggregated platform statistics."""
+    data = await admin_service.get_dashboard_stats()
+    return APIResponse(success=True, data=data)
+
+
+@router.get("/dashboard/recent-activity", response_model=APIResponse)
+async def get_recent_activity(
+    period: str = Query("7d", description="Period: 7d or 30d"),
+    current_admin: dict = Depends(require_admin),
+):
+    """Get daily trade volume and new user counts for charts."""
+    data = await admin_service.get_recent_activity(period)
+    return APIResponse(success=True, data=data)

--- a/backend/services/admin.py
+++ b/backend/services/admin.py
@@ -458,3 +458,331 @@ async def remove_whitelist(whitelist_id: int) -> dict:
 
     await db.execute("DELETE FROM admin_whitelist WHERE id = $1", whitelist_id)
     return existing
+
+
+# =============================================================================
+# Pool Management (#32)
+# =============================================================================
+
+async def get_admin_pools() -> List[dict]:
+    """Get all AMM pools with enriched data for admin view."""
+    db = get_db()
+
+    pools = await db.read(
+        """
+        SELECT
+            ap.pool_id, sc.symbol, sc.symbol_id, sc.base, sc.quote,
+            ap.reserve_base, ap.reserve_quote, ap.k_value, ap.fee_rate,
+            ap.total_lp_shares, ap.total_volume_base, ap.total_volume_quote,
+            ap.total_fees_collected, ap.is_active,
+            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
+            ap.reserve_quote * 2 as tvl_usdt,
+            ap.created_at, ap.updated_at
+        FROM amm_pools ap
+        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
+        ORDER BY ap.reserve_quote * 2 DESC
+        """
+    )
+    return pools
+
+
+async def get_admin_pool(pool_id: str) -> dict:
+    """Get detailed pool info + LP positions + recent swaps."""
+    db = get_db()
+
+    pool = await db.read_one(
+        """
+        SELECT
+            ap.*, sc.symbol, sc.base, sc.quote, sc.market, sc.settle,
+            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
+            ap.reserve_quote * 2 as tvl_usdt
+        FROM amm_pools ap
+        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
+        WHERE ap.pool_id = $1
+        """,
+        pool_id,
+    )
+    if not pool:
+        raise HTTPException(status_code=404, detail=f"Pool '{pool_id}' not found")
+
+    # LP positions
+    lp_positions = await db.read(
+        """
+        SELECT lp.user_id, u.user_name, lp.lp_shares,
+               CASE WHEN $2 > 0 THEN lp.lp_shares / $2 * 100 ELSE 0 END as share_pct
+        FROM lp_positions lp
+        JOIN users u ON lp.user_id = u.user_id
+        WHERE lp.pool_id = $1 AND lp.lp_shares > 0
+        ORDER BY lp.lp_shares DESC
+        """,
+        pool_id,
+        pool["total_lp_shares"],
+    )
+
+    # Recent swaps
+    recent_swaps = await db.read(
+        """
+        SELECT t.trade_id, t.user_id, t.side, t.price, t.quantity,
+               t.quote_amount, t.fee_amount, t.fee_asset, t.created_at
+        FROM trades t
+        WHERE t.symbol_id = $1 AND t.engine_type = 0 AND t.status = 1
+        ORDER BY t.created_at DESC
+        LIMIT 20
+        """,
+        pool["symbol_id"],
+    )
+
+    return {
+        "pool": pool,
+        "lp_positions": lp_positions,
+        "recent_swaps": recent_swaps,
+    }
+
+
+# =============================================================================
+# User Management (#33)
+# =============================================================================
+
+async def get_admin_users(
+    search: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    limit: int = 20,
+    offset: int = 0,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> dict:
+    """Get paginated user list with summary info."""
+    db = get_db()
+
+    # Validate sort_by to prevent SQL injection
+    allowed_sort = {"created_at", "last_login_at", "user_name", "email"}
+    if sort_by not in allowed_sort:
+        sort_by = "created_at"
+    sort_dir = "ASC" if sort_order.lower() == "asc" else "DESC"
+
+    conditions = []
+    params: list = []
+    param_idx = 1
+
+    if search:
+        conditions.append(f"(u.email ILIKE ${param_idx} OR u.user_name ILIKE ${param_idx})")
+        params.append(f"%{search}%")
+        param_idx += 1
+
+    if is_active is not None:
+        conditions.append(f"u.is_active = ${param_idx}")
+        params.append(is_active)
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    total = await db.read_one(
+        f"SELECT COUNT(*) as count FROM users u WHERE {where_clause}",
+        *params,
+    )
+
+    users = await db.read(
+        f"""
+        SELECT u.user_id, u.user_name, u.email, u.is_active,
+               u.created_at, u.last_login_at,
+               (SELECT COUNT(*) FROM trades t WHERE t.user_id = u.user_id) as trade_count
+        FROM users u
+        WHERE {where_clause}
+        ORDER BY u.{sort_by} {sort_dir}
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+        """,
+        *params, limit, offset,
+    )
+
+    return {
+        "users": users,
+        "total": total["count"] if total else 0,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+async def get_admin_user(user_id: str) -> dict:
+    """Get full user profile + balances + recent trades."""
+    db = get_db()
+
+    user = await db.read_one("SELECT * FROM users WHERE user_id = $1", user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User '{user_id}' not found")
+
+    balances = await db.read(
+        """
+        SELECT currency, available, locked, (available + locked) as total
+        FROM user_balances
+        WHERE user_id = $1 AND account_type = 'spot'
+        ORDER BY currency
+        """,
+        user_id,
+    )
+
+    trades = await db.read(
+        """
+        SELECT t.*, sc.symbol
+        FROM trades t
+        JOIN symbol_configs sc USING (symbol_id)
+        WHERE t.user_id = $1
+        ORDER BY t.created_at DESC
+        LIMIT 50
+        """,
+        user_id,
+    )
+
+    return {"user": user, "balances": balances, "trades": trades}
+
+
+async def update_user_balance(user_id: str, currency: str, available: Decimal) -> dict:
+    """Set a user's balance to an absolute value. Returns old and new values."""
+    db = get_db()
+
+    old_balance = await db.read_one(
+        """
+        SELECT available FROM user_balances
+        WHERE user_id = $1 AND currency = $2 AND account_type = 'spot'
+        """,
+        user_id, currency.upper(),
+    )
+    if not old_balance:
+        raise HTTPException(status_code=404, detail=f"Balance for {currency} not found for user {user_id}")
+
+    old_value = old_balance["available"]
+
+    await db.execute(
+        """
+        UPDATE user_balances SET available = $1, updated_at = NOW()
+        WHERE user_id = $2 AND currency = $3 AND account_type = 'spot'
+        """,
+        available, user_id, currency.upper(),
+    )
+
+    return {"old_available": old_value, "new_available": available, "currency": currency.upper()}
+
+
+async def update_user_status(user_id: str, is_active: bool) -> dict:
+    """Enable/disable a user account. Revokes tokens when disabling."""
+    db = get_db()
+
+    user = await db.read_one("SELECT user_id, is_active FROM users WHERE user_id = $1", user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User '{user_id}' not found")
+
+    await db.execute(
+        "UPDATE users SET is_active = $1, updated_at = NOW() WHERE user_id = $2",
+        is_active, user_id,
+    )
+
+    # Revoke all active tokens when disabling
+    if not is_active:
+        await db.execute(
+            "UPDATE access_tokens SET is_active = FALSE WHERE user_id = $1 AND is_active = TRUE",
+            user_id,
+        )
+
+    return {"user_id": user_id, "is_active": is_active, "tokens_revoked": not is_active}
+
+
+async def reset_user_balances(user_id: str) -> dict:
+    """Reset user balances to platform defaults from platform_settings."""
+    db = get_db()
+
+    user = await db.read_one("SELECT user_id FROM users WHERE user_id = $1", user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User '{user_id}' not found")
+
+    # Read init_funding from platform_settings
+    from backend.services.user import _get_init_funding
+    funding = await _get_init_funding()
+
+    for currency, amount in funding.items():
+        await db.execute(
+            """
+            UPDATE user_balances SET available = $1, locked = 0, updated_at = NOW()
+            WHERE user_id = $2 AND currency = $3 AND account_type = 'spot'
+            """,
+            amount, user_id, currency,
+        )
+
+    return {"user_id": user_id, "reset_to": {k: float(v) for k, v in funding.items()}}
+
+
+# =============================================================================
+# Dashboard Stats (#30)
+# =============================================================================
+
+async def get_dashboard_stats() -> dict:
+    """Get aggregated platform statistics."""
+    db = get_db()
+
+    total_users = await db.read_one("SELECT COUNT(*) as count FROM users")
+    active_users_24h = await db.read_one(
+        "SELECT COUNT(*) as count FROM users WHERE last_login_at > NOW() - INTERVAL '24 hours'"
+    )
+    new_users_7d = await db.read_one(
+        "SELECT COUNT(*) as count FROM users WHERE created_at > NOW() - INTERVAL '7 days'"
+    )
+    total_symbols = await db.read_one("SELECT COUNT(*) as count FROM symbol_configs")
+    active_symbols = await db.read_one(
+        "SELECT COUNT(*) as count FROM symbol_configs WHERE is_active = TRUE"
+    )
+    total_pools = await db.read_one("SELECT COUNT(*) as count FROM amm_pools")
+    trades_24h = await db.read_one(
+        "SELECT COUNT(*) as count, COALESCE(SUM(quote_amount), 0) as volume FROM trades WHERE created_at > NOW() - INTERVAL '24 hours' AND status = 1"
+    )
+    pool_tvl = await db.read_one(
+        "SELECT COALESCE(SUM(reserve_quote * 2), 0) as tvl FROM amm_pools WHERE is_active = TRUE"
+    )
+
+    return {
+        "total_users": total_users["count"] if total_users else 0,
+        "active_users_24h": active_users_24h["count"] if active_users_24h else 0,
+        "new_users_7d": new_users_7d["count"] if new_users_7d else 0,
+        "total_symbols": total_symbols["count"] if total_symbols else 0,
+        "active_symbols": active_symbols["count"] if active_symbols else 0,
+        "total_pools": total_pools["count"] if total_pools else 0,
+        "total_trades_24h": trades_24h["count"] if trades_24h else 0,
+        "total_volume_24h_usdt": float(trades_24h["volume"]) if trades_24h else 0,
+        "total_pool_tvl_usdt": float(pool_tvl["tvl"]) if pool_tvl else 0,
+    }
+
+
+async def get_recent_activity(period: str = "7d") -> dict:
+    """Get daily trade volume and new user counts for charts."""
+    db = get_db()
+
+    days = 30 if period == "30d" else 7
+
+    daily_trades = await db.read(
+        """
+        SELECT date_trunc('day', created_at)::date as date,
+               COUNT(*) as count,
+               COALESCE(SUM(quote_amount), 0) as volume_usdt
+        FROM trades
+        WHERE created_at > NOW() - make_interval(days => $1)
+          AND status = 1
+        GROUP BY date_trunc('day', created_at)::date
+        ORDER BY date ASC
+        """,
+        days,
+    )
+
+    daily_new_users = await db.read(
+        """
+        SELECT date_trunc('day', created_at)::date as date,
+               COUNT(*) as count
+        FROM users
+        WHERE created_at > NOW() - make_interval(days => $1)
+        GROUP BY date_trunc('day', created_at)::date
+        ORDER BY date ASC
+        """,
+        days,
+    )
+
+    return {
+        "daily_trades": daily_trades,
+        "daily_new_users": daily_new_users,
+        "period": period,
+    }


### PR DESCRIPTION
## Summary
- Add dashboard statistics API for platform overview (#30)
- Add pool management endpoints for admin monitoring (#32)
- Add user management endpoints with balance adjustment and account control (#33)
- All endpoints follow GET/POST only rule with @audit_logged decorator

## New endpoints (9)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/admin/dashboard/stats` | Platform metrics (users, symbols, trades, volume, TVL) |
| GET | `/api/admin/dashboard/recent-activity` | Daily trades + new users for charts (7d/30d) |
| GET | `/api/admin/pools` | All pools with TVL, price, volume, fees |
| GET | `/api/admin/pools/{pool_id}` | Pool detail + LP positions + recent swaps |
| GET | `/api/admin/users` | Paginated user list with search + filters |
| GET | `/api/admin/users/{user_id}` | Full profile + balances + trade history |
| POST | `/api/admin/users/{user_id}/balance/update` | Adjust balance (absolute value) |
| POST | `/api/admin/users/{user_id}/status/update` | Enable/disable account + revoke tokens |
| POST | `/api/admin/users/{user_id}/reset-balances` | Reset balances to platform defaults |

## Key features

### Dashboard (#30)
- `/stats` returns: total_users, active_users_24h, new_users_7d, total_symbols, active_symbols, total_pools, total_trades_24h, total_volume_24h_usdt, total_pool_tvl_usdt
- `/recent-activity` returns daily_trades and daily_new_users arrays for chart rendering

### Pool management (#32)
- Pool list sorted by TVL descending, includes calculated price and tvl_usdt
- Pool detail includes LP position breakdown (user, shares, percentage) and last 20 swaps

### User management (#33)
- User list supports search (email/username ILIKE), is_active filter, pagination, sort
- Balance update is absolute (set to value), not relative — simpler and audit-friendly
- Disabling a user revokes all their active access tokens
- Reset-balances reads from platform_settings.init_funding (from #34)

## Test plan
- [ ] Dashboard stats returns correct aggregated data
- [ ] Recent activity returns daily bucketed data with 7d/30d toggle
- [ ] Pool list shows all pools with correct TVL and price
- [ ] Pool detail shows LP positions and recent swaps
- [ ] User list search, filter, and pagination work
- [ ] Balance update logs old/new values in audit log
- [ ] Disabling user revokes their tokens
- [ ] Reset balances uses platform_settings.init_funding values
- [ ] All endpoints require admin auth
- [ ] All endpoints use GET/POST only

Closes #30
Closes #32
Closes #33
