### PR TITLE
Consolidate duplicate endpoints and reuse service functions

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,12 +1,12 @@
 """
-Admin API Routes — thin router, delegates to services/admin.py.
+Admin API Routes — thin router, delegates to domain services.
 
 All endpoints require admin permissions.
 """
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from backend.core.audit_log import AuditContext, audit_logged, get_audit_context
 from backend.core.auth import require_admin
@@ -24,6 +24,9 @@ from backend.models.admin import (
     UpdateUserStatusRequest,
 )
 from backend.services import admin as admin_service
+from backend.services import market as market_service
+from backend.services import pool as pool_service
+from backend.services import user as user_service
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -98,42 +101,15 @@ async def delete_symbol(
     return APIResponse(success=True, data=result)
 
 
-# =============================================================================
-# Audit Log Viewer
-# =============================================================================
-
-@router.get("/audit-log", response_model=APIResponse)
-async def get_audit_log(
-    admin_id: Optional[str] = Query(None, description="Filter by admin ID"),
-    action: Optional[str] = Query(None, description="Filter by action type"),
-    target_type: Optional[str] = Query(None, description="Filter by target type"),
-    date_from: Optional[str] = Query(None, description="Start date (ISO format)"),
-    date_to: Optional[str] = Query(None, description="End date (ISO format)"),
-    limit: int = Query(50, ge=1, le=200, description="Page size"),
-    offset: int = Query(0, ge=0, description="Offset"),
-    current_admin: dict = Depends(require_admin),
-):
-    """Query admin audit log with pagination and filters."""
-    data = await admin_service.get_audit_log(
-        admin_id=admin_id, action=action, target_type=target_type,
-        date_from=date_from, date_to=date_to, limit=limit, offset=offset,
-    )
-    return APIResponse(success=True, data=data)
-
-
-# =============================================================================
-# Symbol CRUD (#31)
-# =============================================================================
-
 @router.get("/symbols", response_model=APIResponse)
 async def get_symbols(
     engine_type: Optional[int] = Query(None, description="Filter by engine type: 0=AMM, 1=CLOB"),
-    is_active: Optional[bool] = Query(None, description="Filter by active status"),
+    is_active: Optional[bool] = Query(None, description="Filter by active status (null=all)"),
     market: Optional[str] = Query(None, description="Filter by market type"),
     current_admin: dict = Depends(require_admin),
 ):
-    """Get all symbols with full config. Includes pool info for AMM symbols."""
-    data = await admin_service.get_symbols(engine_type, is_active, market)
+    """Get all symbols with full config. Reuses market_service.get_symbols with is_active=None to include inactive."""
+    data = await market_service.get_symbols(engine_type, is_active, market)
     return APIResponse(success=True, data=data)
 
 
@@ -143,7 +119,7 @@ async def get_symbol(
     current_admin: dict = Depends(require_admin),
 ):
     """Get detailed symbol config + associated pool data."""
-    data = await admin_service.get_symbol(symbol_id)
+    data = await market_service.get_symbol_by_id(symbol_id)
     return APIResponse(success=True, data=data)
 
 
@@ -156,7 +132,7 @@ async def update_symbol(
     current_admin: dict = Depends(require_admin),
     audit: AuditContext = Depends(get_audit_context),
 ):
-    """Update mutable fields of a symbol config. For AMM symbols, also updates pool fee_rate."""
+    """Update mutable fields of a symbol config."""
     data = await admin_service.update_symbol(symbol_id, request, router)
     audit.set(
         target_id=str(symbol_id),
@@ -166,84 +142,13 @@ async def update_symbol(
 
 
 # =============================================================================
-# Platform Settings (#34)
-# =============================================================================
-
-@router.get("/settings", response_model=APIResponse)
-async def get_settings(current_admin: dict = Depends(require_admin)):
-    """Get all platform settings."""
-    data = await admin_service.get_settings()
-    return APIResponse(success=True, data=data)
-
-
-@router.post("/settings/update/{key}", response_model=APIResponse)
-@audit_logged(action="update_setting", target_type="setting")
-async def update_setting(
-    key: str,
-    request: UpdateSettingRequest,
-    current_admin: dict = Depends(require_admin),
-    audit: AuditContext = Depends(get_audit_context),
-):
-    """Update a platform setting."""
-    result = await admin_service.update_setting(key, request.value)
-    audit.set(
-        target_id=key,
-        details={"old": result["old_value"], "new": request.value},
-    )
-    return APIResponse(success=True, data=result["setting"])
-
-
-# =============================================================================
-# Admin Whitelist (#34)
-# =============================================================================
-
-@router.get("/whitelist", response_model=APIResponse)
-async def get_whitelist(current_admin: dict = Depends(require_admin)):
-    """Get all admin whitelist entries."""
-    data = await admin_service.get_whitelist()
-    return APIResponse(success=True, data=data)
-
-
-@router.post("/whitelist", response_model=APIResponse)
-@audit_logged(action="add_whitelist", target_type="whitelist")
-async def add_whitelist(
-    request: AddWhitelistRequest,
-    current_admin: dict = Depends(require_admin),
-    audit: AuditContext = Depends(get_audit_context),
-):
-    """Add an email to admin whitelist."""
-    result = await admin_service.add_whitelist(request.email, request.description)
-    audit.set(
-        target_id=str(result["id"]),
-        details={"email": request.email},
-    )
-    return APIResponse(success=True, data=result)
-
-
-@router.post("/whitelist/remove/{whitelist_id}", response_model=APIResponse)
-@audit_logged(action="remove_whitelist", target_type="whitelist")
-async def remove_whitelist(
-    whitelist_id: int,
-    current_admin: dict = Depends(require_admin),
-    audit: AuditContext = Depends(get_audit_context),
-):
-    """Remove an email from admin whitelist."""
-    result = await admin_service.remove_whitelist(whitelist_id)
-    audit.set(
-        target_id=str(whitelist_id),
-        details={"email": result["email"]},
-    )
-    return APIResponse(success=True, data=result)
-
-
-# =============================================================================
-# Pool Management (#32)
+# Pool Management — reuses pool_service
 # =============================================================================
 
 @router.get("/pools", response_model=APIResponse)
 async def get_admin_pools(current_admin: dict = Depends(require_admin)):
     """Get all AMM pools with enriched data (TVL, price, volume)."""
-    data = await admin_service.get_admin_pools()
+    data = await pool_service.get_all_pools_enriched()
     return APIResponse(success=True, data=data)
 
 
@@ -253,12 +158,12 @@ async def get_admin_pool(
     current_admin: dict = Depends(require_admin),
 ):
     """Get detailed pool info + LP positions + recent swaps."""
-    data = await admin_service.get_admin_pool(pool_id)
+    data = await pool_service.get_pool_detail(pool_id)
     return APIResponse(success=True, data=data)
 
 
 # =============================================================================
-# User Management (#33)
+# User Management — reuses user_service for reads
 # =============================================================================
 
 @router.get("/users", response_model=APIResponse)
@@ -286,8 +191,14 @@ async def get_admin_user(
     current_admin: dict = Depends(require_admin),
 ):
     """Get full user profile + balances + recent trades."""
-    data = await admin_service.get_admin_user(user_id)
-    return APIResponse(success=True, data=data)
+    user = await user_service.get_user_info(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User '{user_id}' not found")
+
+    balances = await user_service.get_user_balances(user_id, include_total=True)
+    trades = await user_service.get_user_trades(user_id, limit=50)
+
+    return APIResponse(success=True, data={"user": user, "balances": balances, "trades": trades})
 
 
 @router.post("/users/{user_id}/balance/update", response_model=APIResponse)
@@ -345,21 +256,108 @@ async def reset_user_balances(
 
 
 # =============================================================================
-# Dashboard Stats (#30)
+# Platform Settings
 # =============================================================================
 
-@router.get("/dashboard/stats", response_model=APIResponse)
-async def get_dashboard_stats(current_admin: dict = Depends(require_admin)):
-    """Get aggregated platform statistics."""
-    data = await admin_service.get_dashboard_stats()
+@router.get("/settings", response_model=APIResponse)
+async def get_settings(current_admin: dict = Depends(require_admin)):
+    """Get all platform settings."""
+    data = await admin_service.get_settings()
     return APIResponse(success=True, data=data)
 
 
-@router.get("/dashboard/recent-activity", response_model=APIResponse)
-async def get_recent_activity(
-    period: str = Query("7d", description="Period: 7d or 30d"),
+@router.post("/settings/update/{key}", response_model=APIResponse)
+@audit_logged(action="update_setting", target_type="setting")
+async def update_setting(
+    key: str,
+    request: UpdateSettingRequest,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Update a platform setting."""
+    result = await admin_service.update_setting(key, request.value)
+    audit.set(
+        target_id=key,
+        details={"old": result["old_value"], "new": request.value},
+    )
+    return APIResponse(success=True, data=result["setting"])
+
+
+# =============================================================================
+# Admin Whitelist
+# =============================================================================
+
+@router.get("/whitelist", response_model=APIResponse)
+async def get_whitelist(current_admin: dict = Depends(require_admin)):
+    """Get all admin whitelist entries."""
+    data = await admin_service.get_whitelist()
+    return APIResponse(success=True, data=data)
+
+
+@router.post("/whitelist", response_model=APIResponse)
+@audit_logged(action="add_whitelist", target_type="whitelist")
+async def add_whitelist(
+    request: AddWhitelistRequest,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Add an email to admin whitelist."""
+    result = await admin_service.add_whitelist(request.email, request.description)
+    audit.set(
+        target_id=str(result["id"]),
+        details={"email": request.email},
+    )
+    return APIResponse(success=True, data=result)
+
+
+@router.post("/whitelist/remove/{whitelist_id}", response_model=APIResponse)
+@audit_logged(action="remove_whitelist", target_type="whitelist")
+async def remove_whitelist(
+    whitelist_id: int,
+    current_admin: dict = Depends(require_admin),
+    audit: AuditContext = Depends(get_audit_context),
+):
+    """Remove an email from admin whitelist."""
+    result = await admin_service.remove_whitelist(whitelist_id)
+    audit.set(
+        target_id=str(whitelist_id),
+        details={"email": result["email"]},
+    )
+    return APIResponse(success=True, data=result)
+
+
+# =============================================================================
+# Audit Log Viewer
+# =============================================================================
+
+@router.get("/audit-log", response_model=APIResponse)
+async def get_audit_log(
+    admin_id: Optional[str] = Query(None, description="Filter by admin ID"),
+    action: Optional[str] = Query(None, description="Filter by action type"),
+    target_type: Optional[str] = Query(None, description="Filter by target type"),
+    date_from: Optional[str] = Query(None, description="Start date (ISO format)"),
+    date_to: Optional[str] = Query(None, description="End date (ISO format)"),
+    limit: int = Query(50, ge=1, le=200, description="Page size"),
+    offset: int = Query(0, ge=0, description="Offset"),
     current_admin: dict = Depends(require_admin),
 ):
-    """Get daily trade volume and new user counts for charts."""
-    data = await admin_service.get_recent_activity(period)
+    """Query admin audit log with pagination and filters."""
+    data = await admin_service.get_audit_log(
+        admin_id=admin_id, action=action, target_type=target_type,
+        date_from=date_from, date_to=date_to, limit=limit, offset=offset,
+    )
+    return APIResponse(success=True, data=data)
+
+
+# =============================================================================
+# Dashboard — stats + recent activity combined
+# =============================================================================
+
+@router.get("/dashboard", response_model=APIResponse)
+async def get_dashboard(
+    period: str = Query("7d", description="Activity period: 7d or 30d"),
+    current_admin: dict = Depends(require_admin),
+):
+    """Get platform stats + recent activity in one call."""
+    data = await admin_service.get_dashboard(period)
     return APIResponse(success=True, data=data)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -4,8 +4,6 @@ Authentication API Routes
 Thin router — delegates all business logic to services/auth.py.
 """
 
-from typing import Optional
-
 from fastapi import APIRouter, Depends, Query
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -23,7 +21,7 @@ router = APIRouter(prefix="/api/auth", tags=["authentication"])
 
 
 # =============================================================================
-# Google OAuth Endpoints
+# Google OAuth
 # =============================================================================
 
 @router.post("/google", response_model=APIResponse)
@@ -40,25 +38,8 @@ async def google_auth(request: GoogleAuthRequest):
 
 
 # =============================================================================
-# Legacy Registration Endpoints (kept for backward compatibility)
+# Email Auth
 # =============================================================================
-
-@router.post("/register", response_model=APIResponse, deprecated=True)
-async def register_user(
-    google_id: str = Query(..., description="Google OAuth ID"),
-    email: str = Query(..., description="User email"),
-    display_name: Optional[str] = Query(None, description="Display name"),
-    avatar_url: Optional[str] = Query(None, description="Avatar URL"),
-):
-    """[DEPRECATED] Register a new user via Google OAuth."""
-    result = await auth_service.register_legacy(
-        google_id=google_id,
-        email=email,
-        display_name=display_name,
-        avatar_url=avatar_url,
-    )
-    return APIResponse(success=True, data=result)
-
 
 @router.post("/register/email", response_model=APIResponse)
 async def register_user_email(request: EmailRegisterRequest):
@@ -68,15 +49,6 @@ async def register_user_email(request: EmailRegisterRequest):
         password=request.password,
         user_name=request.user_name,
     )
-    return APIResponse(success=True, data=result)
-
-
-@router.post("/login", response_model=APIResponse, deprecated=True)
-async def login_user(
-    google_id: str = Query(..., description="Google OAuth ID"),
-):
-    """[DEPRECATED] Use /api/auth/google instead."""
-    result = await auth_service.login_legacy(google_id)
     return APIResponse(success=True, data=result)
 
 
@@ -91,16 +63,16 @@ async def login_user_email(request: EmailLoginRequest):
 async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ):
-    """
-    OAuth2 password grant token endpoint.
-
-    Used by Swagger UI and other OAuth2-compliant clients.
-    """
+    """OAuth2 password grant token endpoint. Used by Swagger UI."""
     return await auth_service.login_oauth2_password(
         email=form_data.username,
         password=form_data.password,
     )
 
+
+# =============================================================================
+# Token Management
+# =============================================================================
 
 @router.post("/logout", response_model=APIResponse)
 async def logout_user(current_user: dict = Depends(get_current_user)):
@@ -119,16 +91,12 @@ async def refresh_token(
 
 
 # =============================================================================
-# Admin Authentication Endpoints
+# Admin Authentication
 # =============================================================================
 
 @router.post("/admin/google", response_model=APIResponse)
 async def admin_google_auth(request: AdminGoogleAuthRequest):
-    """
-    Admin Google OAuth authentication endpoint.
-
-    Validates against admin whitelist. Completely independent from exchange user auth.
-    """
+    """Admin Google OAuth. Validates against admin whitelist."""
     result = await auth_service.admin_google_auth(request.id_token)
     return APIResponse(success=True, data=result)
 
@@ -137,7 +105,7 @@ async def admin_google_auth(request: AdminGoogleAuthRequest):
 async def admin_refresh_token(
     refresh_token: str = Query(..., description="Admin refresh token"),
 ):
-    """Refresh admin access token using admin refresh token."""
+    """Refresh admin access token."""
     result = await auth_service.refresh_admin_token(refresh_token)
     return APIResponse(success=True, data=result)
 

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -25,13 +25,6 @@ async def get_all_markets(
     return APIResponse(success=True, data=data)
 
 
-@router.get("/list_symbols", response_model=APIResponse)
-async def list_symbols(router: EngineRouter = Depends(get_router)):
-    """Get all active trading symbols."""
-    symbols = await market_service.list_symbols(router)
-    return APIResponse(success=True, data=symbols)
-
-
 @router.get("/engines", response_model=APIResponse)
 async def get_symbol_engines(
     symbol: str = Query(..., description="Symbol (e.g. AMM/USDT-USDT:SPOT)"),

--- a/backend/routers/orderbook.py
+++ b/backend/routers/orderbook.py
@@ -79,25 +79,13 @@ async def cancel_order(
     return APIResponse(success=True, data=data)
 
 
-@router.get("/orders", response_model=APIResponse)
-async def get_user_orders(
-    symbol: str = Query(..., description="Symbol"),
-    user_id: str = Depends(get_current_user_id),
-    status: Optional[List[OrderStatus]] = Query(None, description="Filter by status"),
-    limit: int = Query(50, ge=1, le=200, description="Max results"),
-):
-    """Get your orders for a specific CLOB market."""
-    data = await orderbook_service.get_user_orders(user_id, symbol, status, limit)
-    return APIResponse(success=True, data=data)
-
-
 @router.get("/user/orders", response_model=APIResponse)
-async def get_all_user_orders(
+async def get_user_orders(
     user_id: str = Depends(get_current_user_id),
-    symbol: Optional[str] = Query(None, description="Filter by symbol"),
+    symbol: Optional[str] = Query(None, description="Filter by symbol (optional)"),
     status: Optional[List[OrderStatus]] = Query(None, description="Filter by status"),
     limit: int = Query(50, ge=1, le=200, description="Max results"),
 ):
-    """Get all your orders across all CLOB markets."""
+    """Get your orders across all CLOB markets. Optionally filter by symbol."""
     data = await orderbook_service.get_all_user_orders(user_id, symbol, status, limit)
     return APIResponse(success=True, data=data)

--- a/backend/routers/pool.py
+++ b/backend/routers/pool.py
@@ -12,8 +12,7 @@ from backend.core.dependencies import get_router
 from backend.engines.engine_router import EngineRouter
 from backend.models.common import APIResponse
 from backend.models.enums import OrderSide
-from backend.models.pool import PeriodKind
-from backend.models.pool import AddLiquidityRequest, RemoveLiquidityRequest, SwapRequest
+from backend.models.pool import AddLiquidityRequest, PeriodKind, RemoveLiquidityRequest, SwapRequest
 from backend.services import pool as pool_service
 
 router = APIRouter(prefix="/api/pool", tags=["amm-pool"])
@@ -36,17 +35,6 @@ async def get_pool_trades(
 ):
     """Get recent AMM trades for a symbol."""
     data = await pool_service.get_pool_trades(symbol, limit)
-    return APIResponse(success=True, data=data)
-
-
-@router.get("/public", response_model=APIResponse)
-async def get_pool_public(
-    symbol: str = Query(..., description="Symbol in format base-quote-settle-market"),
-    limit: int = Query(100, ge=1, le=200, description="Number of recent trades"),
-    engine_router: EngineRouter = Depends(get_router),
-):
-    """Get public pool data + recent trades in one call."""
-    data = await pool_service.get_pool_public(engine_router, symbol, limit)
     return APIResponse(success=True, data=data)
 
 
@@ -147,17 +135,6 @@ async def remove_liquidity(
     data = await pool_service.remove_liquidity(
         router, user_id, request.symbol, lp_shares=request.lp_shares,
     )
-    return APIResponse(success=True, data=data)
-
-
-@router.get("/liquidity/position", response_model=APIResponse)
-async def get_lp_position(
-    symbol: str = Query(..., description="Symbol in format base-quote-settle-market"),
-    user_id: str = Depends(get_current_user_id),
-    router: EngineRouter = Depends(get_router),
-):
-    """Get your LP position for an AMM pool."""
-    data = await pool_service.get_lp_position(router, user_id, symbol)
     return APIResponse(success=True, data=data)
 
 

--- a/backend/services/admin.py
+++ b/backend/services/admin.py
@@ -238,80 +238,8 @@ async def get_audit_log(
 
 
 # =============================================================================
-# Symbol CRUD (#31)
+# Symbol CRUD (#31) — read functions moved to services/market.py
 # =============================================================================
-
-async def get_symbols(
-    engine_type: Optional[int] = None,
-    is_active: Optional[bool] = None,
-    market: Optional[str] = None,
-) -> List[dict]:
-    """Get all symbols with full config, optionally filtered. Includes pool info for AMM symbols."""
-    db = get_db()
-
-    conditions = []
-    params: list = []
-    param_idx = 1
-
-    if engine_type is not None:
-        conditions.append(f"sc.engine_type = ${param_idx}")
-        params.append(engine_type)
-        param_idx += 1
-
-    if is_active is not None:
-        conditions.append(f"sc.is_active = ${param_idx}")
-        params.append(is_active)
-        param_idx += 1
-
-    if market:
-        conditions.append(f"sc.market = ${param_idx}")
-        params.append(market.upper())
-        param_idx += 1
-
-    where_clause = " AND ".join(conditions) if conditions else "TRUE"
-
-    symbols = await db.read(
-        f"""
-        SELECT sc.*,
-               ap.pool_id, ap.reserve_base, ap.reserve_quote, ap.fee_rate,
-               ap.total_lp_shares, ap.total_volume_quote, ap.total_fees_collected,
-               CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE NULL END as current_price,
-               CASE WHEN ap.reserve_quote IS NOT NULL THEN ap.reserve_quote * 2 ELSE NULL END as tvl_usdt
-        FROM symbol_configs sc
-        LEFT JOIN amm_pools ap ON sc.symbol_id = ap.symbol_id
-        WHERE {where_clause}
-        ORDER BY sc.created_at DESC
-        """,
-        *params,
-    )
-
-    return symbols
-
-
-async def get_symbol(symbol_id: int) -> dict:
-    """Get detailed symbol config + associated pool data (if AMM)."""
-    db = get_db()
-
-    symbol = await db.read_one(
-        """
-        SELECT sc.*,
-               ap.pool_id, ap.reserve_base, ap.reserve_quote, ap.k_value,
-               ap.fee_rate, ap.total_lp_shares, ap.total_volume_base, ap.total_volume_quote,
-               ap.total_fees_collected, ap.is_active as pool_is_active,
-               CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE NULL END as current_price,
-               CASE WHEN ap.reserve_quote IS NOT NULL THEN ap.reserve_quote * 2 ELSE NULL END as tvl_usdt
-        FROM symbol_configs sc
-        LEFT JOIN amm_pools ap ON sc.symbol_id = ap.symbol_id
-        WHERE sc.symbol_id = $1
-        """,
-        symbol_id,
-    )
-
-    if not symbol:
-        raise HTTPException(status_code=404, detail=f"Symbol with id {symbol_id} not found")
-
-    return symbol
-
 
 async def update_symbol(symbol_id: int, request: UpdateSymbolRequest, router: EngineRouter) -> dict:
     """Update mutable fields of a symbol config. For AMM symbols, also update pool fee_rate."""
@@ -376,7 +304,8 @@ async def update_symbol(symbol_id: int, request: UpdateSymbolRequest, router: En
     router.invalidate_cache(existing["symbol"])
 
     # Return updated symbol
-    return await get_symbol(symbol_id)
+    from backend.services.market import get_symbol_by_id
+    return await get_symbol_by_id(symbol_id)
 
 
 # =============================================================================
@@ -461,86 +390,11 @@ async def remove_whitelist(whitelist_id: int) -> dict:
 
 
 # =============================================================================
-# Pool Management (#32)
+# Pool Management (#32) — read functions moved to services/pool.py
 # =============================================================================
 
-async def get_admin_pools() -> List[dict]:
-    """Get all AMM pools with enriched data for admin view."""
-    db = get_db()
-
-    pools = await db.read(
-        """
-        SELECT
-            ap.pool_id, sc.symbol, sc.symbol_id, sc.base, sc.quote,
-            ap.reserve_base, ap.reserve_quote, ap.k_value, ap.fee_rate,
-            ap.total_lp_shares, ap.total_volume_base, ap.total_volume_quote,
-            ap.total_fees_collected, ap.is_active,
-            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
-            ap.reserve_quote * 2 as tvl_usdt,
-            ap.created_at, ap.updated_at
-        FROM amm_pools ap
-        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
-        ORDER BY ap.reserve_quote * 2 DESC
-        """
-    )
-    return pools
-
-
-async def get_admin_pool(pool_id: str) -> dict:
-    """Get detailed pool info + LP positions + recent swaps."""
-    db = get_db()
-
-    pool = await db.read_one(
-        """
-        SELECT
-            ap.*, sc.symbol, sc.base, sc.quote, sc.market, sc.settle,
-            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
-            ap.reserve_quote * 2 as tvl_usdt
-        FROM amm_pools ap
-        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
-        WHERE ap.pool_id = $1
-        """,
-        pool_id,
-    )
-    if not pool:
-        raise HTTPException(status_code=404, detail=f"Pool '{pool_id}' not found")
-
-    # LP positions
-    lp_positions = await db.read(
-        """
-        SELECT lp.user_id, u.user_name, lp.lp_shares,
-               CASE WHEN $2 > 0 THEN lp.lp_shares / $2 * 100 ELSE 0 END as share_pct
-        FROM lp_positions lp
-        JOIN users u ON lp.user_id = u.user_id
-        WHERE lp.pool_id = $1 AND lp.lp_shares > 0
-        ORDER BY lp.lp_shares DESC
-        """,
-        pool_id,
-        pool["total_lp_shares"],
-    )
-
-    # Recent swaps
-    recent_swaps = await db.read(
-        """
-        SELECT t.trade_id, t.user_id, t.side, t.price, t.quantity,
-               t.quote_amount, t.fee_amount, t.fee_asset, t.created_at
-        FROM trades t
-        WHERE t.symbol_id = $1 AND t.engine_type = 0 AND t.status = 1
-        ORDER BY t.created_at DESC
-        LIMIT 20
-        """,
-        pool["symbol_id"],
-    )
-
-    return {
-        "pool": pool,
-        "lp_positions": lp_positions,
-        "recent_swaps": recent_swaps,
-    }
-
-
 # =============================================================================
-# User Management (#33)
+# User Management (#33) — get_admin_user moved to use services/user.py
 # =============================================================================
 
 async def get_admin_users(
@@ -600,39 +454,6 @@ async def get_admin_users(
         "limit": limit,
         "offset": offset,
     }
-
-
-async def get_admin_user(user_id: str) -> dict:
-    """Get full user profile + balances + recent trades."""
-    db = get_db()
-
-    user = await db.read_one("SELECT * FROM users WHERE user_id = $1", user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail=f"User '{user_id}' not found")
-
-    balances = await db.read(
-        """
-        SELECT currency, available, locked, (available + locked) as total
-        FROM user_balances
-        WHERE user_id = $1 AND account_type = 'spot'
-        ORDER BY currency
-        """,
-        user_id,
-    )
-
-    trades = await db.read(
-        """
-        SELECT t.*, sc.symbol
-        FROM trades t
-        JOIN symbol_configs sc USING (symbol_id)
-        WHERE t.user_id = $1
-        ORDER BY t.created_at DESC
-        LIMIT 50
-        """,
-        user_id,
-    )
-
-    return {"user": user, "balances": balances, "trades": trades}
 
 
 async def update_user_balance(user_id: str, currency: str, available: Decimal) -> dict:
@@ -710,13 +531,14 @@ async def reset_user_balances(user_id: str) -> dict:
 
 
 # =============================================================================
-# Dashboard Stats (#30)
+# Dashboard (#30) — stats + recent activity in one call
 # =============================================================================
 
-async def get_dashboard_stats() -> dict:
-    """Get aggregated platform statistics."""
+async def get_dashboard(period: str = "7d") -> dict:
+    """Get platform stats + recent activity in one response."""
     db = get_db()
 
+    # Stats
     total_users = await db.read_one("SELECT COUNT(*) as count FROM users")
     active_users_24h = await db.read_one(
         "SELECT COUNT(*) as count FROM users WHERE last_login_at > NOW() - INTERVAL '24 hours'"
@@ -736,23 +558,7 @@ async def get_dashboard_stats() -> dict:
         "SELECT COALESCE(SUM(reserve_quote * 2), 0) as tvl FROM amm_pools WHERE is_active = TRUE"
     )
 
-    return {
-        "total_users": total_users["count"] if total_users else 0,
-        "active_users_24h": active_users_24h["count"] if active_users_24h else 0,
-        "new_users_7d": new_users_7d["count"] if new_users_7d else 0,
-        "total_symbols": total_symbols["count"] if total_symbols else 0,
-        "active_symbols": active_symbols["count"] if active_symbols else 0,
-        "total_pools": total_pools["count"] if total_pools else 0,
-        "total_trades_24h": trades_24h["count"] if trades_24h else 0,
-        "total_volume_24h_usdt": float(trades_24h["volume"]) if trades_24h else 0,
-        "total_pool_tvl_usdt": float(pool_tvl["tvl"]) if pool_tvl else 0,
-    }
-
-
-async def get_recent_activity(period: str = "7d") -> dict:
-    """Get daily trade volume and new user counts for charts."""
-    db = get_db()
-
+    # Recent activity
     days = 30 if period == "30d" else 7
 
     daily_trades = await db.read(
@@ -782,7 +588,20 @@ async def get_recent_activity(period: str = "7d") -> dict:
     )
 
     return {
-        "daily_trades": daily_trades,
-        "daily_new_users": daily_new_users,
-        "period": period,
+        "stats": {
+            "total_users": total_users["count"] if total_users else 0,
+            "active_users_24h": active_users_24h["count"] if active_users_24h else 0,
+            "new_users_7d": new_users_7d["count"] if new_users_7d else 0,
+            "total_symbols": total_symbols["count"] if total_symbols else 0,
+            "active_symbols": active_symbols["count"] if active_symbols else 0,
+            "total_pools": total_pools["count"] if total_pools else 0,
+            "total_trades_24h": trades_24h["count"] if trades_24h else 0,
+            "total_volume_24h_usdt": float(trades_24h["volume"]) if trades_24h else 0,
+            "total_pool_tvl_usdt": float(pool_tvl["tvl"]) if pool_tvl else 0,
+        },
+        "recent_activity": {
+            "daily_trades": daily_trades,
+            "daily_new_users": daily_new_users,
+            "period": period,
+        },
     }

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -243,39 +243,6 @@ async def google_auth(id_token: str) -> dict:
     }
 
 
-async def register_legacy(
-    google_id: str, email: str, display_name: Optional[str],
-    avatar_url: Optional[str],
-) -> dict:
-    """Legacy Google registration (deprecated)."""
-    db = get_db()
-
-    existing = await db.read_one(
-        "SELECT user_id FROM users WHERE google_id = $1 OR email = $2",
-        google_id, email,
-    )
-    if existing:
-        raise HTTPException(status_code=400, detail="User already exists")
-
-    user_id = await _ensure_unique_user_id()
-
-    user = await db.execute_returning(
-        """
-        INSERT INTO users (user_id, google_id, email, user_name, photo_url)
-        VALUES ($1, $2, $3, $4, $5)
-        RETURNING *
-        """,
-        user_id, google_id, email,
-        display_name or email.split("@")[0],
-        avatar_url,
-    )
-
-    await create_initial_balances(user["user_id"], account_type="spot")
-    balances = await get_user_balances(user["user_id"], include_total=False)
-
-    return {"user": user, "balances": balances}
-
-
 async def register_email(
     email: str, password: str, user_name: Optional[str],
 ) -> dict:
@@ -320,21 +287,6 @@ async def login_email(email: str, password: str) -> dict:
 
     if not verify_password(password, user["hashed_pw"]):
         raise HTTPException(status_code=401, detail="Invalid email or password")
-
-    await _update_last_login(user["user_id"])
-    token_data = await _create_and_store_tokens(user["user_id"])
-    balances = await get_user_balances(user["user_id"], include_total=True)
-
-    return {"user": user, "balances": balances, **token_data}
-
-
-async def login_legacy(google_id: str) -> dict:
-    """Legacy Google login (deprecated)."""
-    db = get_db()
-
-    user = await db.read_one("SELECT * FROM users WHERE google_id = $1", google_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found. Please register first.")
 
     await _update_last_login(user["user_id"])
     token_data = await _create_and_store_tokens(user["user_id"])

--- a/backend/services/market.py
+++ b/backend/services/market.py
@@ -43,9 +43,78 @@ async def get_all_markets(router: EngineRouter, symbol: Optional[str] = None, en
     }
 
 
-async def list_symbols(router: EngineRouter) -> list:
-    """Get all active trading symbols."""
-    return await router.get_all_symbols()
+async def get_symbols(
+    engine_type: Optional[int] = None,
+    is_active: Optional[bool] = True,
+    market: Optional[str] = None,
+) -> list:
+    """
+    Get symbols with full config, optionally filtered.
+    Includes pool info for AMM symbols via LEFT JOIN.
+    Used by both exchange (is_active=True) and admin (is_active=None for all).
+    """
+    db = get_db()
+
+    conditions = []
+    params: list = []
+    param_idx = 1
+
+    if engine_type is not None:
+        conditions.append(f"sc.engine_type = ${param_idx}")
+        params.append(engine_type)
+        param_idx += 1
+
+    if is_active is not None:
+        conditions.append(f"sc.is_active = ${param_idx}")
+        params.append(is_active)
+        param_idx += 1
+
+    if market:
+        conditions.append(f"sc.market = ${param_idx}")
+        params.append(market.upper())
+        param_idx += 1
+
+    where_clause = " AND ".join(conditions) if conditions else "TRUE"
+
+    return await db.read(
+        f"""
+        SELECT sc.*,
+               ap.pool_id, ap.reserve_base, ap.reserve_quote, ap.fee_rate,
+               ap.total_lp_shares, ap.total_volume_quote, ap.total_fees_collected,
+               CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE NULL END as current_price,
+               CASE WHEN ap.reserve_quote IS NOT NULL THEN ap.reserve_quote * 2 ELSE NULL END as tvl_usdt
+        FROM symbol_configs sc
+        LEFT JOIN amm_pools ap ON sc.symbol_id = ap.symbol_id
+        WHERE {where_clause}
+        ORDER BY sc.created_at DESC
+        """,
+        *params,
+    )
+
+
+async def get_symbol_by_id(symbol_id: int) -> dict:
+    """Get detailed symbol config + associated pool data by symbol_id."""
+    db = get_db()
+
+    symbol = await db.read_one(
+        """
+        SELECT sc.*,
+               ap.pool_id, ap.reserve_base, ap.reserve_quote, ap.k_value,
+               ap.fee_rate, ap.total_lp_shares, ap.total_volume_base, ap.total_volume_quote,
+               ap.total_fees_collected, ap.is_active as pool_is_active,
+               CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE NULL END as current_price,
+               CASE WHEN ap.reserve_quote IS NOT NULL THEN ap.reserve_quote * 2 ELSE NULL END as tvl_usdt
+        FROM symbol_configs sc
+        LEFT JOIN amm_pools ap ON sc.symbol_id = ap.symbol_id
+        WHERE sc.symbol_id = $1
+        """,
+        symbol_id,
+    )
+
+    if not symbol:
+        raise HTTPException(status_code=404, detail=f"Symbol with id {symbol_id} not found")
+
+    return symbol
 
 
 async def get_symbol_engines(router: EngineRouter, symbol: str) -> dict:

--- a/backend/services/orderbook.py
+++ b/backend/services/orderbook.py
@@ -151,36 +151,6 @@ async def cancel_order(router: EngineRouter, user_id: str, symbol: str, order_id
     return result
 
 
-async def get_user_orders(
-    user_id: str,
-    symbol: str,
-    status: Optional[List[OrderStatus]] = None,
-    limit: int = 50,
-) -> dict:
-    """Get user's orders for a specific CLOB market."""
-    db = get_db()
-
-    query = """
-        SELECT o.*, sc.symbol FROM orderbook_orders o
-        JOIN symbol_configs sc USING (symbol_id)
-        WHERE o.user_id = $1 AND sc.symbol = $2 AND sc.engine_type = 1
-    """
-    params: list = [user_id, symbol.upper()]
-    param_idx = 3
-
-    if status:
-        status_values = [s.value for s in status]
-        query += f" AND o.status = ANY(${param_idx})"
-        params.append(status_values)
-        param_idx += 1
-
-    query += f" ORDER BY o.created_at DESC LIMIT ${param_idx}"
-    params.append(limit)
-
-    orders = await db.read(query, *params)
-    return {"symbol": symbol.upper(), "orders": orders}
-
-
 async def get_all_user_orders(
     user_id: str,
     symbol: Optional[str] = None,

--- a/backend/services/pool.py
+++ b/backend/services/pool.py
@@ -4,7 +4,7 @@ Pool domain service — AMM pool queries, swap, liquidity, charts.
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import HTTPException
 
@@ -111,50 +111,6 @@ async def get_pool_trades(symbol: str, limit: int = 100) -> dict:
     )
 
     data: dict = {"symbol": symbol_str, "trades": trades}
-    return _enrich_with_components(data, symbol)
-
-
-async def get_pool_public(router: EngineRouter, symbol: str, limit: int = 100) -> dict:
-    """Get public pool data + recent trades in one call."""
-    symbol_str = parse_symbol_path(symbol)
-    engine = await router._get_engine(symbol_str, EngineType.AMM)
-    if not engine:
-        raise HTTPException(status_code=404, detail=f"AMM pool '{symbol_str}' not found")
-
-    pool = await engine._get_pool()
-    if not pool:
-        raise HTTPException(status_code=404, detail=f"No pool data for '{symbol_str}'")
-
-    db = get_db()
-    trades = await db.read(
-        """
-        SELECT t.trade_id, t.side, t.price, t.quantity, t.quote_amount,
-               t.fee_amount, t.fee_asset, t.created_at
-        FROM trades t
-        JOIN symbol_configs sc USING (symbol_id)
-        WHERE sc.symbol = $1 AND sc.engine_type = 0 AND t.status = 1
-        ORDER BY t.created_at DESC
-        LIMIT $2
-        """,
-        symbol_str,
-        limit,
-    )
-
-    data: dict = {
-        "symbol": symbol_str,
-        "pool_id": pool["pool_id"],
-        "reserve_base": float(pool["reserve_base"]),
-        "reserve_quote": float(pool["reserve_quote"]),
-        "k_value": float(pool["k_value"]),
-        "fee_rate": float(pool["fee_rate"]),
-        "total_volume_base": float(pool["total_volume_base"]),
-        "total_volume_quote": float(pool["total_volume_quote"]),
-        "total_fees_collected": float(pool["total_fees_collected"]),
-        "total_lp_shares": float(pool["total_lp_shares"]),
-        "current_price": float(pool["reserve_quote"]) / float(pool["reserve_base"])
-        if float(pool["reserve_base"]) > 0 else 0,
-        "trades": trades,
-    }
     return _enrich_with_components(data, symbol)
 
 
@@ -476,44 +432,6 @@ async def remove_liquidity(router: EngineRouter, user_id: str, symbol: str, lp_s
     return data
 
 
-async def get_lp_position(router: EngineRouter, user_id: str, symbol: str) -> dict:
-    """Get user's LP position for an AMM pool."""
-    symbol_str = parse_symbol_path(symbol)
-    engine = await router._get_engine(symbol_str, EngineType.AMM)
-    if not engine:
-        raise HTTPException(status_code=404, detail=f"AMM pool '{symbol_str}' not found")
-
-    position = await engine._get_lp_position(user_id)
-
-    if not position:
-        data: dict = {"symbol": symbol_str, "lp_shares": 0, "has_position": False}
-        return _enrich_with_components(data, symbol)
-
-    pool = await engine._get_pool()
-    if pool:
-        user_lp = Decimal(str(position["lp_shares"]))
-        total_lp = Decimal(str(pool["total_lp_shares"]))
-        rb = Decimal(str(pool["reserve_base"]))
-        rq = Decimal(str(pool["reserve_quote"]))
-        share_ratio = user_lp / total_lp if total_lp > 0 else Decimal("0")
-        estimated_base = rb * share_ratio
-        estimated_quote = rq * share_ratio
-    else:
-        share_ratio = estimated_base = estimated_quote = Decimal("0")
-
-    data = {
-        "symbol": symbol_str,
-        "lp_shares": float(position["lp_shares"]),
-        "initial_base_amount": float(position["initial_base_amount"]),
-        "initial_quote_amount": float(position["initial_quote_amount"]),
-        "estimated_base_value": float(estimated_base),
-        "estimated_quote_value": float(estimated_quote),
-        "pool_share_percentage": float(share_ratio),
-        "has_position": True,
-    }
-    return _enrich_with_components(data, symbol)
-
-
 async def get_lp_history(router: EngineRouter, user_id: str, symbol: str) -> dict:
     """Get user's LP event history."""
     symbol_str = parse_symbol_path(symbol)
@@ -550,3 +468,74 @@ async def get_lp_history(router: EngineRouter, user_id: str, symbol: str) -> dic
 
     data: dict = {"symbol": symbol_str, "events": formatted}
     return _enrich_with_components(data, symbol)
+
+
+# =============================================================================
+# Shared helpers (used by both pool and admin routers)
+# =============================================================================
+
+async def get_all_pools_enriched() -> List[dict]:
+    """Get all AMM pools with calculated price and TVL. Used by admin and pool list."""
+    db = get_db()
+    return await db.read(
+        """
+        SELECT
+            ap.pool_id, sc.symbol, sc.symbol_id, sc.base, sc.quote,
+            ap.reserve_base, ap.reserve_quote, ap.k_value, ap.fee_rate,
+            ap.total_lp_shares, ap.total_volume_base, ap.total_volume_quote,
+            ap.total_fees_collected, ap.is_active,
+            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
+            ap.reserve_quote * 2 as tvl_usdt,
+            ap.created_at, ap.updated_at
+        FROM amm_pools ap
+        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
+        ORDER BY ap.reserve_quote * 2 DESC
+        """
+    )
+
+
+async def get_pool_detail(pool_id: str) -> dict:
+    """Get pool info + LP positions + recent swaps. Used by admin pool detail."""
+    db = get_db()
+
+    pool = await db.read_one(
+        """
+        SELECT
+            ap.*, sc.symbol, sc.base, sc.quote, sc.market, sc.settle,
+            CASE WHEN ap.reserve_base > 0 THEN ap.reserve_quote / ap.reserve_base ELSE 0 END as price,
+            ap.reserve_quote * 2 as tvl_usdt
+        FROM amm_pools ap
+        JOIN symbol_configs sc ON ap.symbol_id = sc.symbol_id
+        WHERE ap.pool_id = $1
+        """,
+        pool_id,
+    )
+    if not pool:
+        raise HTTPException(status_code=404, detail=f"Pool '{pool_id}' not found")
+
+    lp_positions = await db.read(
+        """
+        SELECT lp.user_id, u.user_name, lp.lp_shares,
+               CASE WHEN $2 > 0 THEN lp.lp_shares / $2 * 100 ELSE 0 END as share_pct
+        FROM lp_positions lp
+        JOIN users u ON lp.user_id = u.user_id
+        WHERE lp.pool_id = $1 AND lp.lp_shares > 0
+        ORDER BY lp.lp_shares DESC
+        """,
+        pool_id,
+        pool["total_lp_shares"],
+    )
+
+    recent_swaps = await db.read(
+        """
+        SELECT t.trade_id, t.user_id, t.side, t.price, t.quantity,
+               t.quote_amount, t.fee_amount, t.fee_asset, t.created_at
+        FROM trades t
+        WHERE t.symbol_id = $1 AND t.engine_type = 0 AND t.status = 1
+        ORDER BY t.created_at DESC
+        LIMIT 20
+        """,
+        pool["symbol_id"],
+    )
+
+    return {"pool": pool, "lp_positions": lp_positions, "recent_swaps": recent_swaps}

--- a/backend/services/user.py
+++ b/backend/services/user.py
@@ -196,3 +196,9 @@ async def get_user_portfolio(user_id: str) -> dict:
         "balances": portfolio_items,
         "total_value_usdt": float(total_value),
     }
+
+
+async def get_user_info(user_id: str) -> Optional[dict]:
+    """Get user record by ID. Returns None if not found."""
+    db = get_db()
+    return await db.read_one("SELECT * FROM users WHERE user_id = $1", user_id)


### PR DESCRIPTION
## Summary
- Consolidate duplicate endpoints by reusing domain service functions
- Remove redundant and deprecated endpoints
- 62 → 55 endpoints, -580 lines of duplicated code

## What changed

### Admin reads → reuse domain services (no new endpoints, just rewired)
| Admin Endpoint | Before | After |
|---------------|--------|-------|
| `GET /admin/symbols` | `admin_service.get_symbols()` | `market_service.get_symbols()` |
| `GET /admin/symbols/{id}` | `admin_service.get_symbol()` | `market_service.get_symbol_by_id()` |
| `GET /admin/pools` | `admin_service.get_admin_pools()` | `pool_service.get_all_pools_enriched()` |
| `GET /admin/pools/{id}` | `admin_service.get_admin_pool()` | `pool_service.get_pool_detail()` |
| `GET /admin/users/{id}` | `admin_service.get_admin_user()` | `user_service.get_user_info()` + `.get_user_balances()` + `.get_user_trades()` |

### Removed endpoints (-7)
| Removed | Replacement |
|---------|-------------|
| `GET /pool/public` | Use `GET /pool` + `GET /pool/trades` separately |
| `GET /pool/liquidity/position` | Merged into `GET /pool/user` |
| `GET /market/list_symbols` | Use `GET /market` |
| `GET /orderbook/orders` | Use `GET /orderbook/user/orders` with optional `symbol` param |
| `GET /admin/dashboard/stats` | Merged into `GET /admin/dashboard` |
| `GET /admin/dashboard/recent-activity` | Merged into `GET /admin/dashboard` |
| `POST /auth/register` (deprecated) | Use `POST /auth/google` |
| `POST /auth/login` (deprecated) | Use `POST /auth/google` |

### Deleted service functions (~10)
- `admin_service`: `get_symbols`, `get_symbol`, `get_admin_pools`, `get_admin_pool`, `get_admin_user`, `get_dashboard_stats`, `get_recent_activity`
- `auth_service`: `register_legacy`, `login_legacy`
- `orderbook_service`: `get_user_orders`
- `pool_service`: `get_pool_public`, `get_lp_position`

### New shared service functions (5)
- `market_service.get_symbols(engine_type, is_active, market)` — filterable symbol query
- `market_service.get_symbol_by_id(symbol_id)` — symbol detail with pool JOIN
- `pool_service.get_all_pools_enriched()` — all pools with TVL/price
- `pool_service.get_pool_detail(pool_id)` — pool + LP positions + swaps
- `user_service.get_user_info(user_id)` — user record lookup

## Test plan
- [ ] Admin symbol/pool/user read endpoints return same data as before
- [ ] `GET /admin/dashboard` returns both stats and recent_activity
- [ ] `GET /orderbook/user/orders` with symbol param works like old `/orders`
- [ ] `GET /pool/user` returns LP position data (covers old `/liquidity/position`)
- [ ] No 404s on removed endpoints from frontend (verify no frontend calls)
- [ ] All 55 endpoints work correctly

Closes #54
