### PR TITLE
Implement Settings, Whitelist, Audit Log, and Symbols pages

### DIFF
--- a/admin_dashboard/src/App.tsx
+++ b/admin_dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import { SymbolsPage } from '@/pages/SymbolsPage'
 import { PoolsPage } from '@/pages/PoolsPage'
 import { UsersPage } from '@/pages/UsersPage'
 import { SettingsPage } from '@/pages/SettingsPage'
+import { WhitelistPage } from '@/pages/WhitelistPage'
 import { AuditLogPage } from '@/pages/AuditLogPage'
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_ADMIN_GOOGLE_CLIENT_ID || ''
@@ -35,6 +36,7 @@ export default function App() {
               <Route path="/pools" element={<PoolsPage />} />
               <Route path="/users" element={<UsersPage />} />
               <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/whitelist" element={<WhitelistPage />} />
               <Route path="/audit-log" element={<AuditLogPage />} />
             </Route>
 

--- a/admin_dashboard/src/api/services/AdminService.ts
+++ b/admin_dashboard/src/api/services/AdminService.ts
@@ -1,0 +1,115 @@
+import client from '@/api/client'
+import type { APIResponse } from '@/types/admin'
+
+export const AdminService = {
+  // ── Settings ──
+  async getSettings(): Promise<APIResponse> {
+    const res = await client.get('/api/admin/settings')
+    return res.data
+  },
+
+  async updateSetting(key: string, value: unknown): Promise<APIResponse> {
+    const res = await client.post(`/api/admin/settings/update/${encodeURIComponent(key)}`, { value })
+    return res.data
+  },
+
+  // ── Whitelist ──
+  async getWhitelist(): Promise<APIResponse> {
+    const res = await client.get('/api/admin/whitelist')
+    return res.data
+  },
+
+  async addWhitelist(email: string, description?: string): Promise<APIResponse> {
+    const res = await client.post('/api/admin/whitelist', { email, description })
+    return res.data
+  },
+
+  async removeWhitelist(id: number): Promise<APIResponse> {
+    const res = await client.post(`/api/admin/whitelist/remove/${id}`)
+    return res.data
+  },
+
+  // ── Audit Log ──
+  async getAuditLog(params: {
+    admin_id?: string
+    action?: string
+    target_type?: string
+    date_from?: string
+    date_to?: string
+    limit?: number
+    offset?: number
+  }): Promise<APIResponse> {
+    const res = await client.get('/api/admin/audit-log', { params })
+    return res.data
+  },
+
+  // ── Symbols ──
+  async getSymbols(params?: {
+    engine_type?: number
+    is_active?: boolean
+    market?: string
+  }): Promise<APIResponse> {
+    const res = await client.get('/api/admin/symbols', { params })
+    return res.data
+  },
+
+  async getSymbol(symbolId: number): Promise<APIResponse> {
+    const res = await client.get(`/api/admin/symbols/${symbolId}`)
+    return res.data
+  },
+
+  async createSymbol(data: {
+    symbol: string
+    base_asset: string
+    quote_asset: string
+    market?: string
+    settle?: string
+    engine_type: number
+    engine_params?: Record<string, unknown>
+    min_trade_amount?: number
+    max_trade_amount?: number
+    price_precision?: number
+    quantity_precision?: number
+  }): Promise<APIResponse> {
+    const res = await client.post('/api/admin/create_symbol', data)
+    return res.data
+  },
+
+  async createPool(data: {
+    symbol: string
+    base_asset: string
+    quote_asset: string
+    market?: string
+    settle?: string
+    initial_reserve_base: number
+    initial_reserve_quote: number
+    fee_rate?: number
+    price_precision?: number
+    quantity_precision?: number
+  }): Promise<APIResponse> {
+    const res = await client.post('/api/admin/create_pool', data)
+    return res.data
+  },
+
+  async updateSymbol(symbolId: number, data: {
+    engine_params?: Record<string, unknown>
+    min_trade_amount?: number
+    max_trade_amount?: number
+    price_precision?: number
+    quantity_precision?: number
+    fee_rate?: number
+  }): Promise<APIResponse> {
+    const res = await client.post(`/api/admin/symbols/update/${symbolId}`, data)
+    return res.data
+  },
+
+  async updateSymbolStatus(symbol: string, status: string): Promise<APIResponse> {
+    const res = await client.post(`/api/admin/update_symbol_status/${encodeURIComponent(symbol)}?status=${status}`)
+    return res.data
+  },
+
+  async deleteSymbol(symbol: string): Promise<APIResponse> {
+    const res = await client.post(`/api/admin/delete_symbol/${encodeURIComponent(symbol)}`)
+    return res.data
+  },
+}

--- a/admin_dashboard/src/components/layout/AdminLayout.tsx
+++ b/admin_dashboard/src/components/layout/AdminLayout.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { to: '/pools', label: 'Pools', icon: '◎' },
   { to: '/users', label: 'Users', icon: '◉' },
   { to: '/settings', label: 'Settings', icon: '⚙' },
+  { to: '/whitelist', label: 'Whitelist', icon: '☰' },
   { to: '/audit-log', label: 'Audit Log', icon: '▤' },
 ]
 

--- a/admin_dashboard/src/pages/AuditLogPage.tsx
+++ b/admin_dashboard/src/pages/AuditLogPage.tsx
@@ -1,11 +1,189 @@
+import { useEffect, useState, useCallback } from 'react'
+import { AdminService } from '@/api/services/AdminService'
+
+interface AuditEntry {
+  id: number
+  admin_id: string
+  admin_name?: string
+  admin_email?: string
+  action: string
+  target_type: string | null
+  target_id: string | null
+  details: Record<string, unknown> | null
+  created_at: string
+}
+
+const PAGE_SIZE = 20
+
 export function AuditLogPage() {
+  const [entries, setEntries] = useState<AuditEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [offset, setOffset] = useState(0)
+
+  // Filters
+  const [actionFilter, setActionFilter] = useState('')
+  const [targetTypeFilter, setTargetTypeFilter] = useState('')
+
+  const loadAuditLog = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params: Record<string, unknown> = { limit: PAGE_SIZE, offset }
+      if (actionFilter) params.action = actionFilter
+      if (targetTypeFilter) params.target_type = targetTypeFilter
+
+      const res = await AdminService.getAuditLog(params as Parameters<typeof AdminService.getAuditLog>[0])
+      if (res.success && res.data) {
+        const data = res.data as { logs: AuditEntry[]; total: number }
+        setEntries(data.logs || [])
+        setTotal(data.total || 0)
+      }
+    } catch (err) {
+      console.error('Failed to load audit log:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [offset, actionFilter, targetTypeFilter])
+
+  useEffect(() => { loadAuditLog() }, [loadAuditLog])
+
+  const handleFilter = () => {
+    setOffset(0)
+    loadAuditLog()
+  }
+
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+
   return (
     <div>
       <h2 className="text-lg font-semibold text-text-primary mb-1">Audit Log</h2>
-      <p className="text-sm text-text-tertiary">History of all admin actions.</p>
-      <div className="mt-6 p-8 border border-border-default rounded-lg text-center text-text-secondary text-sm">
-        Audit log viewer will be implemented here.
+      <p className="text-sm text-text-tertiary mb-6">History of all admin actions.</p>
+
+      {/* Filters */}
+      <div className="mb-4 flex gap-3 items-end">
+        <div>
+          <label className="block text-xs text-text-tertiary mb-1">Action</label>
+          <input
+            type="text"
+            value={actionFilter}
+            onChange={(e) => setActionFilter(e.target.value)}
+            placeholder="e.g. create_symbol"
+            className="px-3 py-1.5 bg-bg-tertiary border border-border-default rounded-md text-sm text-text-primary placeholder-text-tertiary focus:outline-none focus:border-accent-blue"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-text-tertiary mb-1">Target Type</label>
+          <select
+            value={targetTypeFilter}
+            onChange={(e) => setTargetTypeFilter(e.target.value)}
+            className="px-3 py-1.5 bg-bg-tertiary border border-border-default rounded-md text-sm text-text-primary focus:outline-none focus:border-accent-blue"
+          >
+            <option value="">All</option>
+            <option value="symbol">Symbol</option>
+            <option value="pool">Pool</option>
+            <option value="user">User</option>
+            <option value="setting">Setting</option>
+            <option value="whitelist">Whitelist</option>
+          </select>
+        </div>
+        <button
+          onClick={handleFilter}
+          className="px-4 py-1.5 text-sm bg-accent-blue text-white rounded-md hover:bg-accent-blue/80"
+        >
+          Filter
+        </button>
+        {(actionFilter || targetTypeFilter) && (
+          <button
+            onClick={() => { setActionFilter(''); setTargetTypeFilter(''); setOffset(0) }}
+            className="px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary border border-border-default rounded-md"
+          >
+            Clear
+          </button>
+        )}
       </div>
+
+      {/* Table */}
+      <div className="border border-border-default rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
+              <th className="px-4 py-3 font-medium">Time</th>
+              <th className="px-4 py-3 font-medium">Admin</th>
+              <th className="px-4 py-3 font-medium">Action</th>
+              <th className="px-4 py-3 font-medium">Target</th>
+              <th className="px-4 py-3 font-medium">Details</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-default">
+            {loading ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center">
+                  <div className="inline-block w-5 h-5 border-2 border-text-tertiary border-t-accent-blue rounded-full animate-spin" />
+                </td>
+              </tr>
+            ) : entries.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-text-tertiary text-sm">
+                  No audit log entries found.
+                </td>
+              </tr>
+            ) : (
+              entries.map((entry) => (
+                <tr key={entry.id} className="text-sm">
+                  <td className="px-4 py-3 text-text-tertiary text-xs whitespace-nowrap">
+                    {new Date(entry.created_at).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary">
+                    {entry.admin_name || entry.admin_email || entry.admin_id}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="px-2 py-0.5 text-xs rounded bg-bg-hover text-text-primary">
+                      {entry.action}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary text-xs">
+                    {entry.target_type && (
+                      <span className="text-text-tertiary">{entry.target_type}:</span>
+                    )}{' '}
+                    {entry.target_id || '—'}
+                  </td>
+                  <td className="px-4 py-3 max-w-xs">
+                    {entry.details ? (
+                      <code className="text-xs text-text-tertiary break-all">
+                        {JSON.stringify(entry.details)}
+                      </code>
+                    ) : '—'}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4 text-sm text-text-secondary">
+          <span>Page {currentPage} of {totalPages} ({total} entries)</span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0}
+              className="px-3 py-1 border border-border-default rounded-md hover:border-border-hover disabled:opacity-30"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total}
+              className="px-3 py-1 border border-border-default rounded-md hover:border-border-hover disabled:opacity-30"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/admin_dashboard/src/pages/SettingsPage.tsx
+++ b/admin_dashboard/src/pages/SettingsPage.tsx
@@ -1,10 +1,153 @@
+import { useEffect, useState, useCallback } from 'react'
+import { AdminService } from '@/api/services/AdminService'
+
+interface Setting {
+  key: string
+  value: unknown
+  description: string | null
+  updated_at: string
+}
+
 export function SettingsPage() {
+  const [settings, setSettings] = useState<Setting[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null)
+
+  const loadSettings = useCallback(async () => {
+    try {
+      const res = await AdminService.getSettings()
+      if (res.success && res.data) setSettings(res.data as Setting[])
+    } catch (err) {
+      console.error('Failed to load settings:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadSettings() }, [loadSettings])
+
+  const handleEdit = (setting: Setting) => {
+    setEditingKey(setting.key)
+    setEditValue(JSON.stringify(setting.value, null, 2))
+    setMessage(null)
+  }
+
+  const handleCancel = () => {
+    setEditingKey(null)
+    setEditValue('')
+  }
+
+  const handleSave = async (key: string) => {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const parsed = JSON.parse(editValue)
+      const res = await AdminService.updateSetting(key, parsed)
+      if (res.success) {
+        setMessage({ text: `Setting "${key}" updated successfully.`, type: 'success' })
+        setEditingKey(null)
+        loadSettings()
+      }
+    } catch (err) {
+      const msg = err instanceof SyntaxError ? 'Invalid JSON format' : 'Failed to update setting'
+      setMessage({ text: msg, type: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="w-5 h-5 border-2 border-text-tertiary border-t-accent-blue rounded-full animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <div>
       <h2 className="text-lg font-semibold text-text-primary mb-1">Settings</h2>
-      <p className="text-sm text-text-tertiary">Platform configuration and admin whitelist.</p>
-      <div className="mt-6 p-8 border border-border-default rounded-lg text-center text-text-secondary text-sm">
-        Platform settings will be implemented here.
+      <p className="text-sm text-text-tertiary mb-6">Platform-wide configuration values.</p>
+
+      {message && (
+        <div className={`mb-4 p-3 text-sm rounded-lg ${
+          message.type === 'success'
+            ? 'bg-accent-green/10 text-accent-green border border-accent-green/20'
+            : 'bg-accent-red/10 text-accent-red border border-accent-red/20'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      <div className="border border-border-default rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
+              <th className="px-4 py-3 font-medium">Key</th>
+              <th className="px-4 py-3 font-medium">Value</th>
+              <th className="px-4 py-3 font-medium">Description</th>
+              <th className="px-4 py-3 font-medium">Updated</th>
+              <th className="px-4 py-3 font-medium text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-default">
+            {settings.map((s) => (
+              <tr key={s.key} className="text-sm">
+                <td className="px-4 py-3 font-mono text-text-primary">{s.key}</td>
+                <td className="px-4 py-3 max-w-xs">
+                  {editingKey === s.key ? (
+                    <textarea
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      rows={4}
+                      className="w-full px-3 py-2 bg-bg-tertiary border border-border-default rounded-md text-text-primary font-mono text-xs focus:outline-none focus:border-accent-blue"
+                    />
+                  ) : (
+                    <code className="text-xs text-text-secondary break-all">
+                      {JSON.stringify(s.value)}
+                    </code>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-text-secondary">{s.description || '—'}</td>
+                <td className="px-4 py-3 text-text-tertiary text-xs">
+                  {new Date(s.updated_at).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {editingKey === s.key ? (
+                    <div className="flex gap-2 justify-end">
+                      <button
+                        onClick={() => handleSave(s.key)}
+                        disabled={saving}
+                        className="px-3 py-1 text-xs bg-accent-blue text-white rounded-md hover:bg-accent-blue/80 disabled:opacity-50"
+                      >
+                        {saving ? 'Saving...' : 'Save'}
+                      </button>
+                      <button
+                        onClick={handleCancel}
+                        className="px-3 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => handleEdit(s)}
+                      className="px-3 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md hover:border-border-hover"
+                    >
+                      Edit
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {settings.length === 0 && (
+          <div className="text-center py-8 text-text-tertiary text-sm">No settings found.</div>
+        )}
       </div>
     </div>
   )

--- a/admin_dashboard/src/pages/SymbolsPage.tsx
+++ b/admin_dashboard/src/pages/SymbolsPage.tsx
@@ -1,11 +1,432 @@
+import { useEffect, useState, useCallback } from 'react'
+import { AdminService } from '@/api/services/AdminService'
+
+interface SymbolConfig {
+  symbol_id: number
+  symbol: string
+  base: string
+  quote: string
+  market: string
+  settle: string
+  engine_type: number
+  engine_params: Record<string, unknown>
+  min_trade_amount: number
+  max_trade_amount: number
+  price_precision: number
+  quantity_precision: number
+  is_active: boolean
+  created_at: string
+}
+
+type ModalType = 'create_clob' | 'create_pool' | 'edit' | null
+
 export function SymbolsPage() {
+  const [symbols, setSymbols] = useState<SymbolConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modal, setModal] = useState<ModalType>(null)
+  const [editTarget, setEditTarget] = useState<SymbolConfig | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null)
+  const [confirmDeleteSymbol, setConfirmDeleteSymbol] = useState<string | null>(null)
+
+  // Filter
+  const [engineFilter, setEngineFilter] = useState<string>('')
+
+  // Create CLOB form
+  const [clobForm, setClobForm] = useState({
+    base_asset: '', quote_asset: '', market: 'SPOT', settle: '',
+    price_precision: 8, quantity_precision: 8,
+  })
+
+  // Create Pool form
+  const [poolForm, setPoolForm] = useState({
+    base_asset: '', quote_asset: '', market: 'SPOT', settle: '',
+    initial_reserve_base: 1000, initial_reserve_quote: 1000,
+    fee_rate: 0.003, price_precision: 8, quantity_precision: 8,
+  })
+
+  // Edit form
+  const [editForm, setEditForm] = useState({
+    min_trade_amount: 0, max_trade_amount: 0,
+    price_precision: 8, quantity_precision: 8, fee_rate: 0,
+  })
+
+  const loadSymbols = useCallback(async () => {
+    try {
+      const params: Record<string, unknown> = {}
+      if (engineFilter) params.engine_type = parseInt(engineFilter)
+      const res = await AdminService.getSymbols(params as Parameters<typeof AdminService.getSymbols>[0])
+      if (res.success && res.data) setSymbols(res.data as SymbolConfig[])
+    } catch (err) {
+      console.error('Failed to load symbols:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [engineFilter])
+
+  useEffect(() => { loadSymbols() }, [loadSymbols])
+
+  const buildSymbol = (base: string, quote: string, settle: string, market: string) => {
+    const s = settle || quote
+    return `${base.toUpperCase()}/${quote.toUpperCase()}-${s.toUpperCase()}:${market.toUpperCase()}`
+  }
+
+  const handleCreateClob = async () => {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const symbol = buildSymbol(clobForm.base_asset, clobForm.quote_asset, clobForm.settle || clobForm.quote_asset, clobForm.market)
+      const res = await AdminService.createSymbol({
+        symbol,
+        base_asset: clobForm.base_asset.toUpperCase(),
+        quote_asset: clobForm.quote_asset.toUpperCase(),
+        market: clobForm.market.toUpperCase(),
+        settle: (clobForm.settle || clobForm.quote_asset).toUpperCase(),
+        engine_type: 1,
+        price_precision: clobForm.price_precision,
+        quantity_precision: clobForm.quantity_precision,
+      })
+      if (res.success) {
+        setMessage({ text: `CLOB symbol ${symbol} created.`, type: 'success' })
+        setModal(null)
+        setClobForm({ base_asset: '', quote_asset: '', market: 'SPOT', settle: '', price_precision: 8, quantity_precision: 8 })
+        loadSymbols()
+      }
+    } catch (err) {
+      const axiosErr = err as { response?: { data?: { detail?: string } } }
+      setMessage({ text: axiosErr.response?.data?.detail || 'Failed to create symbol', type: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleCreatePool = async () => {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const symbol = buildSymbol(poolForm.base_asset, poolForm.quote_asset, poolForm.settle || poolForm.quote_asset, poolForm.market)
+      const res = await AdminService.createPool({
+        symbol,
+        base_asset: poolForm.base_asset.toUpperCase(),
+        quote_asset: poolForm.quote_asset.toUpperCase(),
+        market: poolForm.market.toUpperCase(),
+        settle: (poolForm.settle || poolForm.quote_asset).toUpperCase(),
+        initial_reserve_base: poolForm.initial_reserve_base,
+        initial_reserve_quote: poolForm.initial_reserve_quote,
+        fee_rate: poolForm.fee_rate,
+        price_precision: poolForm.price_precision,
+        quantity_precision: poolForm.quantity_precision,
+      })
+      if (res.success) {
+        setMessage({ text: `AMM pool ${symbol} created.`, type: 'success' })
+        setModal(null)
+        loadSymbols()
+      }
+    } catch (err) {
+      const axiosErr = err as { response?: { data?: { detail?: string } } }
+      setMessage({ text: axiosErr.response?.data?.detail || 'Failed to create pool', type: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const openEdit = (s: SymbolConfig) => {
+    setEditTarget(s)
+    setEditForm({
+      min_trade_amount: s.min_trade_amount,
+      max_trade_amount: s.max_trade_amount,
+      price_precision: s.price_precision,
+      quantity_precision: s.quantity_precision,
+      fee_rate: (s.engine_params as { fee_rate?: number })?.fee_rate || (s.engine_params as { maker_fee?: number })?.maker_fee || 0,
+    })
+    setModal('edit')
+  }
+
+  const handleEdit = async () => {
+    if (!editTarget) return
+    setSaving(true)
+    setMessage(null)
+    try {
+      const res = await AdminService.updateSymbol(editTarget.symbol_id, {
+        min_trade_amount: editForm.min_trade_amount,
+        max_trade_amount: editForm.max_trade_amount,
+        price_precision: editForm.price_precision,
+        quantity_precision: editForm.quantity_precision,
+        fee_rate: editForm.fee_rate || undefined,
+      })
+      if (res.success) {
+        setMessage({ text: `Symbol ${editTarget.symbol} updated.`, type: 'success' })
+        setModal(null)
+        setEditTarget(null)
+        loadSymbols()
+      }
+    } catch (err) {
+      const axiosErr = err as { response?: { data?: { detail?: string } } }
+      setMessage({ text: axiosErr.response?.data?.detail || 'Failed to update', type: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleToggleStatus = async (s: SymbolConfig) => {
+    try {
+      const newStatus = s.is_active ? 'MAINTENANCE' : 'ACTIVE'
+      await AdminService.updateSymbolStatus(s.symbol, newStatus)
+      loadSymbols()
+    } catch (err) {
+      console.error('Failed to toggle status:', err)
+    }
+  }
+
+  const handleDelete = async (symbol: string) => {
+    if (confirmDeleteSymbol !== symbol) {
+      setConfirmDeleteSymbol(symbol)
+      return
+    }
+    try {
+      await AdminService.deleteSymbol(symbol)
+      setMessage({ text: `Symbol ${symbol} deleted.`, type: 'success' })
+      setConfirmDeleteSymbol(null)
+      loadSymbols()
+    } catch (err) {
+      console.error('Failed to delete:', err)
+      setMessage({ text: 'Failed to delete symbol', type: 'error' })
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="w-5 h-5 border-2 border-text-tertiary border-t-accent-blue rounded-full animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <div>
-      <h2 className="text-lg font-semibold text-text-primary mb-1">Symbols</h2>
-      <p className="text-sm text-text-tertiary">Manage trading pair configurations.</p>
-      <div className="mt-6 p-8 border border-border-default rounded-lg text-center text-text-secondary text-sm">
-        Symbol management will be implemented here.
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-lg font-semibold text-text-primary mb-1">Symbols</h2>
+          <p className="text-sm text-text-tertiary">Manage trading pairs and AMM pools.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setModal('create_clob')}
+            className="px-4 py-2 text-sm bg-accent-blue text-white rounded-md hover:bg-accent-blue/80"
+          >
+            + CLOB Symbol
+          </button>
+          <button
+            onClick={() => setModal('create_pool')}
+            className="px-4 py-2 text-sm bg-accent-green text-white rounded-md hover:bg-accent-green/80"
+          >
+            + AMM Pool
+          </button>
+        </div>
       </div>
+
+      {message && (
+        <div className={`mb-4 p-3 text-sm rounded-lg ${
+          message.type === 'success'
+            ? 'bg-accent-green/10 text-accent-green border border-accent-green/20'
+            : 'bg-accent-red/10 text-accent-red border border-accent-red/20'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      {/* Filter */}
+      <div className="mb-4 flex gap-2">
+        {['', '0', '1'].map((val) => (
+          <button
+            key={val}
+            onClick={() => setEngineFilter(val)}
+            className={`px-3 py-1 text-xs rounded-md ${
+              engineFilter === val
+                ? 'bg-accent-blue text-white'
+                : 'text-text-secondary border border-border-default hover:border-border-hover'
+            }`}
+          >
+            {val === '' ? 'All' : val === '0' ? 'AMM' : 'CLOB'}
+          </button>
+        ))}
+      </div>
+
+      {/* Table */}
+      <div className="border border-border-default rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
+              <th className="px-4 py-3 font-medium">Symbol</th>
+              <th className="px-4 py-3 font-medium">Engine</th>
+              <th className="px-4 py-3 font-medium">Base / Quote</th>
+              <th className="px-4 py-3 font-medium">Precision</th>
+              <th className="px-4 py-3 font-medium">Status</th>
+              <th className="px-4 py-3 font-medium text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-default">
+            {symbols.map((s) => (
+              <tr key={s.symbol_id} className="text-sm">
+                <td className="px-4 py-3 font-mono text-text-primary">{s.symbol}</td>
+                <td className="px-4 py-3">
+                  <span className={`px-2 py-0.5 text-xs rounded ${
+                    s.engine_type === 0
+                      ? 'bg-accent-green/10 text-accent-green'
+                      : 'bg-accent-blue/10 text-accent-blue'
+                  }`}>
+                    {s.engine_type === 0 ? 'AMM' : 'CLOB'}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-text-secondary">{s.base} / {s.quote}</td>
+                <td className="px-4 py-3 text-text-tertiary text-xs">
+                  P:{s.price_precision} Q:{s.quantity_precision}
+                </td>
+                <td className="px-4 py-3">
+                  <button
+                    onClick={() => handleToggleStatus(s)}
+                    className={`px-2 py-0.5 text-xs rounded cursor-pointer ${
+                      s.is_active
+                        ? 'bg-accent-green/10 text-accent-green'
+                        : 'bg-accent-yellow/10 text-accent-yellow'
+                    }`}
+                  >
+                    {s.is_active ? 'Active' : 'Maintenance'}
+                  </button>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex gap-1 justify-end">
+                    <button
+                      onClick={() => openEdit(s)}
+                      className="px-2 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(s.symbol)}
+                      className={`px-2 py-1 text-xs rounded-md border ${
+                        confirmDeleteSymbol === s.symbol
+                          ? 'bg-accent-red/10 text-accent-red border-accent-red/20'
+                          : 'text-text-tertiary hover:text-accent-red border-border-default'
+                      }`}
+                    >
+                      {confirmDeleteSymbol === s.symbol ? 'Confirm' : 'Delete'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {symbols.length === 0 && (
+          <div className="text-center py-8 text-text-tertiary text-sm">No symbols found.</div>
+        )}
+      </div>
+
+      {/* ── Modals ── */}
+      {modal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => setModal(null)}>
+          <div className="bg-bg-secondary border border-border-default rounded-lg p-6 w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+
+            {/* Create CLOB */}
+            {modal === 'create_clob' && (
+              <>
+                <h3 className="text-lg font-semibold text-text-primary mb-4">Create CLOB Symbol</h3>
+                <div className="space-y-3">
+                  <FormField label="Base Asset" value={clobForm.base_asset} onChange={(v) => setClobForm({ ...clobForm, base_asset: v })} placeholder="BTC" />
+                  <FormField label="Quote Asset" value={clobForm.quote_asset} onChange={(v) => setClobForm({ ...clobForm, quote_asset: v })} placeholder="USDT" />
+                  <FormField label="Market" value={clobForm.market} onChange={(v) => setClobForm({ ...clobForm, market: v })} placeholder="SPOT" />
+                  <FormField label="Settle (default=quote)" value={clobForm.settle} onChange={(v) => setClobForm({ ...clobForm, settle: v })} placeholder="USDT" />
+                  <div className="flex gap-3">
+                    <FormField label="Price Precision" value={String(clobForm.price_precision)} onChange={(v) => setClobForm({ ...clobForm, price_precision: parseInt(v) || 8 })} type="number" />
+                    <FormField label="Qty Precision" value={String(clobForm.quantity_precision)} onChange={(v) => setClobForm({ ...clobForm, quantity_precision: parseInt(v) || 8 })} type="number" />
+                  </div>
+                </div>
+                <ModalActions saving={saving} onSave={handleCreateClob} onCancel={() => setModal(null)} label="Create" />
+              </>
+            )}
+
+            {/* Create Pool */}
+            {modal === 'create_pool' && (
+              <>
+                <h3 className="text-lg font-semibold text-text-primary mb-4">Create AMM Pool</h3>
+                <div className="space-y-3">
+                  <FormField label="Base Asset" value={poolForm.base_asset} onChange={(v) => setPoolForm({ ...poolForm, base_asset: v })} placeholder="VEGA" />
+                  <FormField label="Quote Asset" value={poolForm.quote_asset} onChange={(v) => setPoolForm({ ...poolForm, quote_asset: v })} placeholder="USDT" />
+                  <FormField label="Market" value={poolForm.market} onChange={(v) => setPoolForm({ ...poolForm, market: v })} placeholder="SPOT" />
+                  <div className="flex gap-3">
+                    <FormField label="Init Reserve Base" value={String(poolForm.initial_reserve_base)} onChange={(v) => setPoolForm({ ...poolForm, initial_reserve_base: parseFloat(v) || 0 })} type="number" />
+                    <FormField label="Init Reserve Quote" value={String(poolForm.initial_reserve_quote)} onChange={(v) => setPoolForm({ ...poolForm, initial_reserve_quote: parseFloat(v) || 0 })} type="number" />
+                  </div>
+                  <FormField label="Fee Rate" value={String(poolForm.fee_rate)} onChange={(v) => setPoolForm({ ...poolForm, fee_rate: parseFloat(v) || 0.003 })} type="number" />
+                </div>
+                <ModalActions saving={saving} onSave={handleCreatePool} onCancel={() => setModal(null)} label="Create" />
+              </>
+            )}
+
+            {/* Edit */}
+            {modal === 'edit' && editTarget && (
+              <>
+                <h3 className="text-lg font-semibold text-text-primary mb-1">Edit Symbol</h3>
+                <p className="text-sm text-text-tertiary mb-4 font-mono">{editTarget.symbol}</p>
+                <div className="space-y-3">
+                  <div className="flex gap-3">
+                    <FormField label="Min Trade" value={String(editForm.min_trade_amount)} onChange={(v) => setEditForm({ ...editForm, min_trade_amount: parseFloat(v) || 0 })} type="number" />
+                    <FormField label="Max Trade" value={String(editForm.max_trade_amount)} onChange={(v) => setEditForm({ ...editForm, max_trade_amount: parseFloat(v) || 0 })} type="number" />
+                  </div>
+                  <div className="flex gap-3">
+                    <FormField label="Price Precision" value={String(editForm.price_precision)} onChange={(v) => setEditForm({ ...editForm, price_precision: parseInt(v) || 8 })} type="number" />
+                    <FormField label="Qty Precision" value={String(editForm.quantity_precision)} onChange={(v) => setEditForm({ ...editForm, quantity_precision: parseInt(v) || 8 })} type="number" />
+                  </div>
+                  <FormField label="Fee Rate" value={String(editForm.fee_rate)} onChange={(v) => setEditForm({ ...editForm, fee_rate: parseFloat(v) || 0 })} type="number" />
+                </div>
+                <ModalActions saving={saving} onSave={handleEdit} onCancel={() => setModal(null)} label="Save" />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Reusable form components ──
+
+function FormField({ label, value, onChange, placeholder, type = 'text' }: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  type?: string
+}) {
+  return (
+    <div className="flex-1">
+      <label className="block text-xs text-text-tertiary mb-1">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full px-3 py-2 bg-bg-tertiary border border-border-default rounded-md text-sm text-text-primary placeholder-text-tertiary focus:outline-none focus:border-accent-blue"
+      />
+    </div>
+  )
+}
+
+function ModalActions({ saving, onSave, onCancel, label }: {
+  saving: boolean
+  onSave: () => void
+  onCancel: () => void
+  label: string
+}) {
+  return (
+    <div className="flex gap-2 justify-end mt-6">
+      <button onClick={onCancel} className="px-4 py-2 text-sm text-text-secondary border border-border-default rounded-md hover:border-border-hover">
+        Cancel
+      </button>
+      <button onClick={onSave} disabled={saving} className="px-4 py-2 text-sm bg-accent-blue text-white rounded-md hover:bg-accent-blue/80 disabled:opacity-50">
+        {saving ? 'Saving...' : label}
+      </button>
     </div>
   )
 }

--- a/admin_dashboard/src/pages/WhitelistPage.tsx
+++ b/admin_dashboard/src/pages/WhitelistPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState, useCallback } from 'react'
+import { AdminService } from '@/api/services/AdminService'
+
+interface WhitelistEntry {
+  id: number
+  email: string
+  description: string | null
+  created_at: string
+}
+
+export function WhitelistPage() {
+  const [entries, setEntries] = useState<WhitelistEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [newEmail, setNewEmail] = useState('')
+  const [newDesc, setNewDesc] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [removingId, setRemovingId] = useState<number | null>(null)
+  const [confirmRemoveId, setConfirmRemoveId] = useState<number | null>(null)
+  const [message, setMessage] = useState<{ text: string; type: 'success' | 'error' } | null>(null)
+
+  const loadWhitelist = useCallback(async () => {
+    try {
+      const res = await AdminService.getWhitelist()
+      if (res.success && res.data) setEntries(res.data as WhitelistEntry[])
+    } catch (err) {
+      console.error('Failed to load whitelist:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { loadWhitelist() }, [loadWhitelist])
+
+  const handleAdd = async () => {
+    if (!newEmail.trim()) return
+    setAdding(true)
+    setMessage(null)
+    try {
+      const res = await AdminService.addWhitelist(newEmail.trim(), newDesc.trim() || undefined)
+      if (res.success) {
+        setMessage({ text: `Added ${newEmail} to whitelist.`, type: 'success' })
+        setNewEmail('')
+        setNewDesc('')
+        loadWhitelist()
+      }
+    } catch (err) {
+      const axiosErr = err as { response?: { data?: { detail?: string } } }
+      setMessage({ text: axiosErr.response?.data?.detail || 'Failed to add email', type: 'error' })
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleRemove = async (id: number) => {
+    if (confirmRemoveId !== id) {
+      setConfirmRemoveId(id)
+      return
+    }
+    setRemovingId(id)
+    setMessage(null)
+    try {
+      const res = await AdminService.removeWhitelist(id)
+      if (res.success) {
+        setMessage({ text: 'Email removed from whitelist.', type: 'success' })
+        setConfirmRemoveId(null)
+        loadWhitelist()
+      }
+    } catch (err) {
+      console.error('Failed to remove:', err)
+      setMessage({ text: 'Failed to remove email', type: 'error' })
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="w-5 h-5 border-2 border-text-tertiary border-t-accent-blue rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold text-text-primary mb-1">Admin Whitelist</h2>
+      <p className="text-sm text-text-tertiary mb-6">Only whitelisted emails can sign in to the admin dashboard.</p>
+
+      {message && (
+        <div className={`mb-4 p-3 text-sm rounded-lg ${
+          message.type === 'success'
+            ? 'bg-accent-green/10 text-accent-green border border-accent-green/20'
+            : 'bg-accent-red/10 text-accent-red border border-accent-red/20'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      {/* Add form */}
+      <div className="mb-6 p-4 border border-border-default rounded-lg bg-bg-secondary">
+        <h3 className="text-sm font-medium text-text-primary mb-3">Add Email</h3>
+        <div className="flex gap-3">
+          <input
+            type="email"
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.target.value)}
+            placeholder="admin@example.com"
+            className="flex-1 px-3 py-2 bg-bg-tertiary border border-border-default rounded-md text-sm text-text-primary placeholder-text-tertiary focus:outline-none focus:border-accent-blue"
+          />
+          <input
+            type="text"
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+            placeholder="Description (optional)"
+            className="flex-1 px-3 py-2 bg-bg-tertiary border border-border-default rounded-md text-sm text-text-primary placeholder-text-tertiary focus:outline-none focus:border-accent-blue"
+          />
+          <button
+            onClick={handleAdd}
+            disabled={adding || !newEmail.trim()}
+            className="px-4 py-2 text-sm bg-accent-blue text-white rounded-md hover:bg-accent-blue/80 disabled:opacity-50"
+          >
+            {adding ? 'Adding...' : 'Add'}
+          </button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="border border-border-default rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
+              <th className="px-4 py-3 font-medium">Email</th>
+              <th className="px-4 py-3 font-medium">Description</th>
+              <th className="px-4 py-3 font-medium">Added</th>
+              <th className="px-4 py-3 font-medium text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-default">
+            {entries.map((entry) => (
+              <tr key={entry.id} className="text-sm">
+                <td className="px-4 py-3 text-text-primary">{entry.email}</td>
+                <td className="px-4 py-3 text-text-secondary">{entry.description || '—'}</td>
+                <td className="px-4 py-3 text-text-tertiary text-xs">
+                  {new Date(entry.created_at).toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <button
+                    onClick={() => handleRemove(entry.id)}
+                    disabled={removingId === entry.id}
+                    className={`px-3 py-1 text-xs rounded-md border ${
+                      confirmRemoveId === entry.id
+                        ? 'bg-accent-red/10 text-accent-red border-accent-red/20'
+                        : 'text-text-secondary hover:text-text-primary border-border-default hover:border-border-hover'
+                    } disabled:opacity-50`}
+                  >
+                    {removingId === entry.id ? 'Removing...' : confirmRemoveId === entry.id ? 'Confirm Remove' : 'Remove'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {entries.length === 0 && (
+          <div className="text-center py-8 text-text-tertiary text-sm">No whitelist entries. Add one above.</div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- **#56**: Settings page — view/edit platform settings with inline JSON editor
- **#57**: Whitelist page — list, add, remove admin emails
- **#58**: Audit Log page — filterable/paginated log viewer
- **#59**: Symbols page — full CRUD for CLOB symbols and AMM pools

## Changes

### AdminService API layer
Centralized API service covering all admin endpoints: settings CRUD, whitelist CRUD, audit log query, symbol CRUD (create CLOB/AMM, edit, status toggle, delete).

### Settings Page
- Table: key, value (JSON), description, updated_at
- Inline edit: click Edit → textarea JSON editor → Save/Cancel
- Validation: rejects invalid JSON with error message

### Whitelist Page
- Table: email, description, created_at, remove button
- Add form: email + optional description
- Two-click remove confirmation

### Audit Log Page
- Table: time, admin name, action badge, target, details (JSON)
- Filters: action text input, target_type dropdown
- Offset-based pagination

### Symbols Page
- Table with engine badge (AMM green / CLOB blue), status toggle, edit/delete
- Create CLOB Symbol and Create AMM Pool modals
- Edit Symbol modal for mutable fields
- Engine type filter tabs

### Routing
- Added /whitelist route and sidebar nav item

## Test plan
- [ ] Settings: load, edit, save
- [ ] Whitelist: add, remove with confirm
- [ ] Audit Log: filter + pagination
- [ ] Symbols: create CLOB, create AMM pool, edit, toggle status, delete

Closes #56, Closes #57, Closes #58, Closes #59