### PR TITLE
Refactor frontend routing to Trade/Pools market taxonomy

### DIFF
--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -276,6 +276,38 @@ Refer to [domain-knowledge.md](domain-knowledge.md) for:
 | Environment | `backend/core/environment.py` |
 | Backend .env | `backend/.env` |
 
+## Market Taxonomy & Balance Model
+
+VegaExchange organizes markets by **user intent** (Trade vs Pools), not by engine type.
+
+### Market Classification
+```
+symbol_configs.market  ×  symbol_configs.engine_type  →  Frontend Section
+─────────────────────────────────────────────────────────────────────
+SPOT                      0 (AMM)                        Pools (swap + LP)
+SPOT                      1 (CLOB)                       Trade → Spot (order book)
+PERP                      1 (CLOB)                       Trade → Perp (futures)
+```
+
+### Balance Model
+```
+user_balances.account_type:
+├── 'spot'   — shared by ALL Spot trades (CLOB) and AMM swaps
+└── 'perp'   — independent margin account for perpetual futures (future)
+```
+
+- Same pair (e.g., VEGA/USDT) can exist on AMM and CLOB simultaneously
+- Spot CLOB and AMM swap deduct from the **same** spot balance
+- Perp will use separate balance (future: transfer between spot ↔ perp)
+
+### When Creating New Symbols
+- `market='SPOT', engine_type=0` → AMM pool (requires initial reserves)
+- `market='SPOT', engine_type=1` → CLOB order book
+- `market='PERP', engine_type=1` → Perpetual futures (future)
+- Always set `settle` to the settlement currency (usually quote asset)
+
+---
+
 ## Current Architecture Awareness
 
 ### Model-Router-Service Pattern

--- a/.claude/skills/fe/SKILL.md
+++ b/.claude/skills/fe/SKILL.md
@@ -249,7 +249,57 @@ const useAuthStore = create<AuthStore>()(
 
 ---
 
-## Routing Architecture (Target)
+## Market Taxonomy — CRITICAL UX GUIDELINE
+
+VegaExchange organizes markets by **user intent**, not by engine type. This is a core UX
+decision that affects routing, navigation, and component structure.
+
+### Three Top-Level Sections
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Header Nav:   [Trade ▾]     [Pools]     [Dashboard]            │
+│                 ├─ Spot                                         │
+│                 └─ Perp (future)                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+| Section | User Intent | Engine | Balance |
+|---------|------------|--------|---------|
+| **Trade → Spot** | "I want to buy/sell a token" | CLOB (order book) | `account_type='spot'` |
+| **Trade → Perp** | "I want to trade perpetual futures" | CLOB + margin + funding | `account_type='perp'` (future) |
+| **Pools** | "I want to provide liquidity / swap via AMM" | AMM (constant product) | `account_type='spot'` (shared with Trade Spot) |
+
+### Key UX Rules
+
+1. **Trade and Pools are separate top-level nav items** — AMM swap is NOT under "Trade"
+   - Trade = order book (Binance-style, price/quantity/orderbook UI)
+   - Pools = AMM swap (Uniswap-style, from/to/slippage UI)
+   - Even if the same pair (e.g., VEGA/USDT) exists in both, they are different pages
+
+2. **Same pair, different engines** — VegaExchange's unique feature is that the same
+   token pair can trade on multiple engines simultaneously. The frontend should make it
+   easy to compare prices across engines (arbitrage simulation).
+
+3. **Balance is shared within spot** — All Spot trades (CLOB) and AMM swaps use the
+   same `account_type='spot'` balance. Users don't need to "transfer" between spot and AMM.
+   Perp will use a separate `account_type='perp'` balance (future).
+
+4. **Engine type is a backend concept, not a user-facing category** — Users see
+   "Spot" and "Pools", not "CLOB" and "AMM". The engine badge (AMM/CLOB) can appear
+   as a small label for power users but should not be the primary navigation axis.
+
+### DB ↔ Frontend Mapping
+
+| `symbol_configs.market` | `symbol_configs.engine_type` | Frontend Section |
+|------------------------|------------------------------|-----------------|
+| `SPOT` | `0` (AMM) | **Pools** — AMM swap + LP management |
+| `SPOT` | `1` (CLOB) | **Trade → Spot** — order book trading |
+| `PERP` | `1` (CLOB) | **Trade → Perp** — perpetual futures (future) |
+
+---
+
+## Routing Architecture
 
 ### Route Structure
 ```
@@ -258,35 +308,33 @@ const useAuthStore = create<AuthStore>()(
 /register                      → PublicRoute → RegisterPage
 
 /dashboard                     → ProtectedRoute → DashboardPage
-                                  (portfolio, balances, positions summary)
+                                  (portfolio, spot + perp balances, positions)
 
-# Trading (grouped by engine)
+# Trade section (CLOB order book markets)
 /trade/spot/:pair              → ProtectedRoute → SpotTradingPage
                                   (e.g. /trade/spot/BTC-USDT)
-/trade/amm/:pair               → ProtectedRoute → AmmTradingPage
-                                  (e.g. /trade/amm/ETH-USDT)
 /trade/perp/:pair              → ProtectedRoute → PerpTradingPage
-                                  (e.g. /trade/perp/BTC-USDT)
+                                  (e.g. /trade/perp/BTC-USDT) [future]
 
-# Pool management (AMM only)
+# Pools section (AMM liquidity pools)
 /pools                         → ProtectedRoute → PoolsListPage
 /pools/:pair                   → ProtectedRoute → PoolDetailPage
-                                  (e.g. /pools/ETH-USDT)
+                                  (e.g. /pools/VEGA-USDT)
 
-# Market overview
+# Market overview (cross-section directory)
 /markets                       → ProtectedRoute → MarketsPage
-                                  (all markets with Spot/AMM/Perp tabs)
+                                  (tabs: Spot | Pools | Perp)
 
 # Account
 /account/history               → ProtectedRoute → TradeHistoryPage
 ```
 
 ### Route Design Principles
-- Engine type is encoded in the **route path** (`/trade/spot/`), not in the symbol
-- Symbol simplified to `BASE-QUOTE` (e.g., `BTC-USDT`), no settle/market suffix
-- `/trade/:engine/:pair` is the unified trading entry — extensible for future engine types
-- Pool management is a separate top-level section (different UX from trading)
-- `/markets` provides cross-engine overview with tab navigation
+- **Trade = CLOB only** — `/trade/spot/:pair` always shows an order book UI
+- **Pools = AMM only** — `/pools/:pair` always shows a swap + LP UI
+- No `/trade/amm/` route — AMM goes under `/pools/`
+- Symbol simplified to `BASE-QUOTE` in URLs
+- `/markets` provides a directory linking to the correct section per engine type
 
 ### Symbol Format Mapping
 | Context | Format | Example |
@@ -295,8 +343,6 @@ const useAuthStore = create<AuthStore>()(
 | Display | `BASE/QUOTE` | `BTC/USDT` |
 | API query | `BASE-QUOTE-SETTLE-MARKET` | `BTC-USDT-USDT-SPOT` |
 
-Conversion utilities in `src/utils/market.ts` handle all format transformations.
-
 ---
 
 ## Component Architecture
@@ -304,86 +350,74 @@ Conversion utilities in `src/utils/market.ts` handle all format transformations.
 ### Directory Convention
 ```
 src/components/
-├── ui/                    # shadcn/ui components (auto-generated)
-│   ├── button.tsx
-│   ├── dialog.tsx
-│   ├── tabs.tsx
+├── ui/                    # shadcn/ui components (source-owned)
 │   └── ...
 │
-├── common/                # Custom shared components
+├── common/                # Shared components
 │   ├── LoadingSpinner.tsx
 │   ├── ErrorBoundary.tsx
 │   └── ...
 │
 ├── layout/                # App layout
-│   ├── MainLayout.tsx
-│   ├── Header.tsx
-│   └── TradingLayout.tsx  # Shared layout for all trading pages
+│   ├── MainLayout.tsx     # Header + main outlet
+│   ├── Header.tsx         # Nav: Trade (dropdown: Spot/Perp), Pools, Dashboard
+│   └── TradingLayout.tsx  # Shared layout for CLOB trading pages
 │
-├── auth/                  # Authentication
-│   ├── LoginPage.tsx
-│   ├── RegisterPage.tsx
-│   └── ...
+├── auth/                  # Login, Register
 │
-├── dashboard/             # Dashboard
+├── dashboard/             # Portfolio overview
 │   ├── DashboardPage.tsx
-│   ├── PortfolioSummary.tsx
+│   ├── PortfolioSummary.tsx  # Spot + Perp balance breakdown
 │   └── ...
 │
-├── trading/               # Trading components (shared across engines)
-│   ├── common/            # Shared trading UI
+├── trading/               # CLOB trading (Trade section)
+│   ├── common/            # Shared across spot and perp
 │   │   ├── PairSelector.tsx
-│   │   ├── PriceDisplay.tsx
-│   │   └── TradeHistory.tsx
-│   ├── spot/              # CLOB-specific
+│   │   ├── TradeHistory.tsx
+│   │   └── PriceDisplay.tsx
+│   ├── spot/              # Spot CLOB
 │   │   ├── SpotTradingPage.tsx
 │   │   ├── OrderForm.tsx
 │   │   └── OrderBook.tsx
-│   ├── amm/               # AMM-specific
-│   │   ├── AmmTradingPage.tsx
-│   │   └── SwapPanel.tsx
-│   └── perp/              # Perpetual-specific
+│   └── perp/              # Perp CLOB (future)
 │       ├── PerpTradingPage.tsx
 │       ├── PositionPanel.tsx
 │       ├── MarginControl.tsx
 │       └── FundingRateBar.tsx
 │
-├── pool/                  # AMM pool management
-│   ├── PoolsListPage.tsx
-│   ├── PoolDetailPage.tsx
+├── pool/                  # AMM pools (Pools section)
+│   ├── PoolsListPage.tsx  # All AMM pools overview
+│   ├── PoolDetailPage.tsx # Swap + LP + charts
 │   └── ...
 │
-├── market/                # Market overview
-│   ├── MarketsPage.tsx
-│   └── ...
+├── market/                # Market directory (cross-section)
+│   └── MarketsPage.tsx    # Tabs: Spot | Pools | Perp
 │
-├── charts/                # Chart components
+├── charts/                # Chart components (shared)
 │   ├── CandlestickChart.tsx
 │   ├── PriceLineChart.tsx
 │   ├── VolumeBarChart.tsx
-│   ├── DepthChart.tsx     # Order book depth visualization
+│   ├── DepthChart.tsx
 │   └── ...
 │
-└── account/               # Account pages
-    ├── TradeHistoryPage.tsx
-    └── ...
+└── account/               # Trade history, (future: transfers)
+    └── TradeHistoryPage.tsx
 ```
 
 ### Component Design Principles
-1. **Page components** — Route-level, handles data fetching (TanStack Query), layout composition
+1. **Page components** — Route-level, data fetching, layout composition
 2. **Feature components** — Domain logic, connected to stores/queries
-3. **UI components** — Pure presentational, props-driven, reusable
-4. **Composition over inheritance** — Use children/render props, not class hierarchies
+3. **UI components** — Pure presentational, props-driven
+4. **Composition over inheritance** — children/render props
 
 ### Shared Trading Layout
-All trading pages (`/trade/spot/:pair`, `/trade/amm/:pair`, `/trade/perp/:pair`) share a
-common `TradingLayout` with:
-- Header with pair selector + engine switcher
-- Chart area (left/center)
+Spot and Perp trading pages share `TradingLayout`:
+- Header with pair selector
+- Chart area (center)
 - Trade panel (right sidebar)
-- Trade history (bottom)
+- Order/trade history (bottom tabs)
 
-Engine-specific content is rendered via children/slots.
+Engine-specific content (order form, position panel) rendered via children.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,9 @@ import { LoginPage } from './components/auth/LoginPage'
 import { RegisterPage } from './components/auth/RegisterPage'
 import { DashboardPage } from './components/dashboard/DashboardPage'
 import { TradingPage } from './components/trading/TradingPage'
-import { PoolDetailPage } from './components/pool/PoolDetailPage'
 import { MarketPage } from './components/market/MarketPage'
+import { PoolsListPage } from './components/pool/PoolsListPage'
+import { PoolDetailPage } from './components/pool/PoolDetailPage'
 import { LoadingSpinner } from './components/common/LoadingSpinner'
 
 // Protected route wrapper
@@ -48,28 +49,13 @@ const PublicRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 }
 
 function App() {
-  // Initialize auth state on app load
   useAuthInitialization()
 
   return (
     <Routes>
       {/* Public Routes */}
-      <Route
-        path="/login"
-        element={
-          <PublicRoute>
-            <LoginPage />
-          </PublicRoute>
-        }
-      />
-      <Route
-        path="/register"
-        element={
-          <PublicRoute>
-            <RegisterPage />
-          </PublicRoute>
-        }
-      />
+      <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+      <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
 
       {/* Protected Routes */}
       <Route
@@ -82,10 +68,18 @@ function App() {
       >
         <Route index element={<Navigate to="/dashboard" replace />} />
         <Route path="dashboard" element={<DashboardPage />} />
-        <Route path="trade" element={<TradingPage />} />
-        <Route path="trade/:marketId" element={<TradingPage />} />
-        <Route path="pools/:symbolPath" element={<PoolDetailPage />} />
-        <Route path="market/:base/:quote/:settle/:market" element={<MarketPage />} />
+
+        {/* Trade section (CLOB order book) */}
+        <Route path="trade" element={<Navigate to="/trade/spot" replace />} />
+        <Route path="trade/spot" element={<TradingPage />} />
+        <Route path="trade/spot/:pair" element={<MarketPage />} />
+
+        {/* Pools section (AMM) */}
+        <Route path="pools" element={<PoolsListPage />} />
+        <Route path="pools/:pair" element={<PoolDetailPage />} />
+
+        {/* Legacy redirects */}
+        <Route path="market/:base/:quote/:settle/:market" element={<Navigate to="/trade/spot" replace />} />
       </Route>
 
       {/* Catch all */}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,13 +7,18 @@ export const Header: React.FC = () => {
   const { logout } = useAuth()
   const { user } = useUser()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isTradeOpen, setIsTradeOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const tradeRef = useRef<HTMLDivElement>(null)
 
-  // Close dropdown when clicking outside
+  // Close dropdowns when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsDropdownOpen(false)
+      }
+      if (tradeRef.current && !tradeRef.current.contains(event.target as Node)) {
+        setIsTradeOpen(false)
       }
     }
 
@@ -25,10 +30,8 @@ export const Header: React.FC = () => {
     await logout()
   }
 
-  const navLinks = [
-    { path: '/dashboard', label: 'Dashboard' },
-    { path: '/trade', label: 'Trade' },
-  ]
+  const isTradeActive = location.pathname.startsWith('/trade')
+  const isPoolsActive = location.pathname.startsWith('/pools')
 
   return (
     <header className="bg-bg-secondary border-b border-border-default">
@@ -53,19 +56,67 @@ export const Header: React.FC = () => {
 
             {/* Navigation */}
             <nav className="flex items-center gap-1">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.path}
-                  to={link.path}
-                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    location.pathname === link.path || (link.path === '/trade' && location.pathname.startsWith('/trade'))
+              {/* Dashboard */}
+              <Link
+                to="/dashboard"
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  location.pathname === '/dashboard'
+                    ? 'bg-bg-tertiary text-text-primary'
+                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50'
+                }`}
+              >
+                Dashboard
+              </Link>
+
+              {/* Trade dropdown */}
+              <div className="relative" ref={tradeRef}>
+                <button
+                  onClick={() => setIsTradeOpen(!isTradeOpen)}
+                  className={`flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    isTradeActive
                       ? 'bg-bg-tertiary text-text-primary'
                       : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50'
                   }`}
                 >
-                  {link.label}
-                </Link>
-              ))}
+                  Trade
+                  <svg
+                    className={`w-3 h-3 transition-transform ${isTradeOpen ? 'rotate-180' : ''}`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+
+                {isTradeOpen && (
+                  <div className="absolute left-0 mt-1 w-40 bg-bg-secondary border border-border-default rounded-lg shadow-card py-1 z-50 animate-fade-in">
+                    <Link
+                      to="/trade/spot"
+                      onClick={() => setIsTradeOpen(false)}
+                      className="block px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+                    >
+                      Spot
+                    </Link>
+                    <div className="px-4 py-2 text-sm text-text-tertiary cursor-not-allowed flex items-center justify-between">
+                      Perp
+                      <span className="text-xs bg-bg-tertiary px-1.5 py-0.5 rounded">Soon</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Pools */}
+              <Link
+                to="/pools"
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isPoolsActive
+                    ? 'bg-bg-tertiary text-text-primary'
+                    : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/50'
+                }`}
+              >
+                Pools
+              </Link>
             </nav>
           </div>
 
@@ -75,44 +126,30 @@ export const Header: React.FC = () => {
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-bg-tertiary transition-colors"
             >
-              {/* Avatar */}
               <div className="w-8 h-8 rounded-full bg-accent-blue/20 flex items-center justify-center">
                 {user?.photo_url ? (
-                  <img
-                    src={user.photo_url}
-                    alt={user.user_name}
-                    className="w-8 h-8 rounded-full"
-                  />
+                  <img src={user.photo_url} alt={user.user_name} className="w-8 h-8 rounded-full" />
                 ) : (
                   <span className="text-sm font-medium text-accent-blue">
                     {user?.user_name?.charAt(0).toUpperCase() || user?.email?.charAt(0).toUpperCase() || 'U'}
                   </span>
                 )}
               </div>
-              
-              {/* Name */}
               <span className="text-sm text-text-primary hidden sm:block">
                 {user?.user_name || user?.email?.split('@')[0] || 'User'}
               </span>
-
-              {/* Chevron */}
               <svg
                 className={`w-4 h-4 text-text-tertiary transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
 
-            {/* Dropdown Menu */}
             {isDropdownOpen && (
               <div className="absolute right-0 mt-2 w-48 bg-bg-secondary border border-border-default rounded-lg shadow-card py-1 z-50 animate-fade-in">
                 <div className="px-4 py-2 border-b border-border-default">
-                  <p className="text-sm font-medium text-text-primary truncate">
-                    {user?.user_name || 'User'}
-                  </p>
+                  <p className="text-sm font-medium text-text-primary truncate">{user?.user_name || 'User'}</p>
                   <p className="text-xs text-text-tertiary truncate">{user?.email}</p>
                 </div>
                 <button

--- a/frontend/src/components/market/MarketPage.tsx
+++ b/frontend/src/components/market/MarketPage.tsx
@@ -6,7 +6,7 @@ import { Card, CardHeader, Button, LoadingSpinner } from '../common'
 import { TradeHistory } from '../trading/TradeHistory'
 import { CandlestickChart, OrderbookChart } from '../charts'
 import { marketService, tradeService } from '../../api'
-import { formatCrypto, formatNumber, parseNumericInput, isValidAmount, buildSymbolFromPath } from '../../utils'
+import { formatCrypto, formatNumber, parseNumericInput, isValidAmount, buildSymbolFromPath, parsePairParam } from '../../utils'
 import { useWebSocket } from '../../hooks/useWebSocket'
 import type { TradeSide, OrderType, OrderbookLevel, Order, Trade, Symbol as SymbolType, CandlestickData as AppCandlestickData, OrderStatus } from '../../types'
 import type { CandlestickData } from 'lightweight-charts'
@@ -25,19 +25,16 @@ const WS_SIDE_MAP: Record<number, TradeSide> = {
 }
 
 export const MarketPage: React.FC = () => {
-  const { base, quote, settle, market } = useParams<{
-    base: string
-    quote: string
-    settle: string
-    market: string
-  }>()
+  const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
-  
-  // Build symbol from URL path components
+
+  // Build symbol from simplified URL param (e.g. "BTC-USDT" → "BTC/USDT-USDT:SPOT")
   const decodedSymbol = useMemo(() => {
-    if (!base || !quote || !settle || !market) return ''
-    return buildSymbolFromPath({ base, quote, settle, market })
-  }, [base, quote, settle, market])
+    if (!pair) return ''
+    const components = parsePairParam(pair, 'SPOT')
+    if (!components) return ''
+    return buildSymbolFromPath(components)
+  }, [pair])
 
   const {
     symbols,
@@ -491,7 +488,7 @@ export const MarketPage: React.FC = () => {
 
   // Handle back navigation
   const handleBack = () => {
-    navigate('/trade')
+    navigate('/trade/spot')
   }
 
   // Set market order price

--- a/frontend/src/components/pool/PoolDetailPage.tsx
+++ b/frontend/src/components/pool/PoolDetailPage.tsx
@@ -9,18 +9,23 @@ import { AddLiquidityPanel } from './AddLiquidityPanel'
 import { PoolChartSection } from './PoolChartSection'
 import { PoolStatsSidebar } from './PoolStatsSidebar'
 import { LPPieChart } from '../charts'
-import { formatCrypto, formatNumber, formatPercentage, buildSymbolFromPath, parsePoolUrlPath } from '../../utils'
+import { formatCrypto, formatNumber, formatPercentage, buildSymbolFromPath, parsePoolUrlPath, parsePairParam } from '../../utils'
 import type { TradeSide } from '../../types'
 
 export const PoolDetailPage: React.FC = () => {
-  const { symbolPath } = useParams<{ symbolPath: string }>()
+  const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
 
   const decodedSymbol = useMemo(() => {
-    const components = symbolPath ? parsePoolUrlPath(symbolPath) : null
-    if (!components) return ''
-    return buildSymbolFromPath(components)
-  }, [symbolPath])
+    if (!pair) return ''
+    // Try new simplified format first (e.g. "VEGA-USDT")
+    const simplified = parsePairParam(pair, 'SPOT')
+    if (simplified) return buildSymbolFromPath(simplified)
+    // Fallback: old 4-segment format (e.g. "AMM-USDT-USDT-SPOT")
+    const legacy = parsePoolUrlPath(pair)
+    if (legacy) return buildSymbolFromPath(legacy)
+    return ''
+  }, [pair])
 
   const {
     poolInfo,
@@ -141,7 +146,7 @@ export const PoolDetailPage: React.FC = () => {
   )
 
   const handleBack = () => {
-    navigate('/trade')
+    navigate('/pools')
   }
 
   if (isLoading && !poolInfo) {
@@ -177,7 +182,7 @@ export const PoolDetailPage: React.FC = () => {
       {/* Uniswap-style compact header */}
       <div className="space-y-2">
         <nav className="text-sm">
-          <Link to="/trade" className="text-text-tertiary hover:text-text-secondary">
+          <Link to="/pools" className="text-text-tertiary hover:text-text-secondary">
             Pools
           </Link>
           <span className="text-text-tertiary mx-2">/</span>

--- a/frontend/src/components/pool/PoolsListPage.tsx
+++ b/frontend/src/components/pool/PoolsListPage.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Card, LoadingSpinner } from '../common'
+import { marketService } from '../../api'
+import { formatNumber, toPoolPath, getDisplayName } from '../../utils'
+import type { Symbol as SymbolType } from '../../types'
+
+export const PoolsListPage: React.FC = () => {
+  const navigate = useNavigate()
+  const [pools, setPools] = useState<SymbolType[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadPools = useCallback(async () => {
+    try {
+      const response = await marketService.getSymbols()
+      if (response.success && response.data) {
+        // Filter to AMM pools only (engine_type=0)
+        const ammPools = (response.data as SymbolType[]).filter(
+          (s) => s.engine_type === 0
+        )
+        setPools(ammPools)
+      }
+    } catch (err) {
+      console.error('Failed to load pools:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadPools()
+  }, [loadPools])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <LoadingSpinner size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">Pools</h1>
+        <p className="text-text-secondary mt-1">AMM liquidity pools — swap tokens and earn fees.</p>
+      </div>
+
+      {pools.length === 0 ? (
+        <Card className="text-center py-12">
+          <p className="text-text-secondary">No active pools available.</p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {pools.map((pool) => (
+            <button
+              key={pool.symbol_id ?? pool.symbol}
+              onClick={() => navigate(toPoolPath(pool))}
+              className="w-full text-left p-5 bg-bg-secondary border border-border-default rounded-lg hover:border-border-hover transition-all group"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-full bg-accent-green/10 flex items-center justify-center">
+                    <span className="text-sm font-bold text-accent-green">
+                      {pool.base?.charAt(0)}
+                    </span>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-text-primary group-hover:text-accent-blue transition-colors">
+                      {getDisplayName(pool)}
+                    </p>
+                    <p className="text-xs text-text-tertiary">AMM Pool</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <p className="text-text-tertiary text-xs">Price</p>
+                  <p className="text-text-primary font-mono">
+                    {formatNumber(pool.current_price || 0, 6)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-text-tertiary text-xs">Fee Rate</p>
+                  <p className="text-text-primary font-mono">
+                    {(((pool as unknown as { fee_rate?: number }).fee_rate || 0.003) * 100).toFixed(2)}%
+                  </p>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/trading/TradingPage.tsx
+++ b/frontend/src/components/trading/TradingPage.tsx
@@ -2,139 +2,80 @@ import React, { useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTrading, useTradingInitialization } from '../../hooks'
 import { Card, CardHeader } from '../common'
-import { getDisplayName, groupSymbolsByEngine, toPoolUrlPath, toMarketUrlPath } from '../../utils'
+import { getDisplayName, groupSymbolsByEngine, toSpotTradePath } from '../../utils'
 import type { Symbol } from '../../types'
-
-// Market Card Component
-const MarketCard: React.FC<{
-  symbol: Symbol
-  isSelected: boolean
-  onSelect: () => void
-  variant?: 'amm' | 'clob'
-}> = ({ symbol, isSelected, onSelect, variant = 'amm' }) => {
-  const accentColor = variant === 'amm' ? 'accent-blue' : 'accent-purple'
-  
-  return (
-    <button
-      onClick={onSelect}
-      className={`w-full p-3 rounded-lg border text-left transition-all ${
-        isSelected
-          ? `bg-${accentColor}/10 border-${accentColor}`
-          : 'bg-bg-tertiary border-border-default hover:border-border-hover'
-      }`}
-    >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <div className={`w-8 h-8 rounded-full ${variant === 'amm' ? 'bg-accent-blue/20' : 'bg-purple-500/20'} flex items-center justify-center`}>
-            <span className={`text-xs font-bold ${variant === 'amm' ? 'text-accent-blue' : 'text-purple-400'}`}>
-              {symbol.base?.charAt(0)}
-            </span>
-          </div>
-          <div>
-            <p className="font-medium text-text-primary">{getDisplayName(symbol)}</p>
-            <p className="text-xs text-text-tertiary">
-              {variant === 'amm' ? 'AMM Pool' : 'Order Book'} • {symbol.market?.toUpperCase() || 'SPOT'}
-            </p>
-          </div>
-        </div>
-        {symbol.current_price && (
-          <span className="text-sm text-text-secondary">
-            ${symbol.current_price.toFixed(2)}
-          </span>
-        )}
-      </div>
-    </button>
-  )
-}
 
 export const TradingPage: React.FC = () => {
   const navigate = useNavigate()
   const { symbols, loadSymbols } = useTrading()
 
-  // Initialize trading data
   useTradingInitialization()
 
-  // Group symbols by engine type
-  const { amm: ammSymbols, clob: clobSymbols } = useMemo(
-    () => groupSymbolsByEngine(symbols),
+  // Only show CLOB spot markets
+  const spotMarkets = useMemo(
+    () => groupSymbolsByEngine(symbols).clob,
     [symbols]
   )
 
-  // Load symbols on mount
   useEffect(() => {
     if (symbols.length === 0) {
       loadSymbols()
     }
   }, [symbols.length, loadSymbols])
 
-  // Navigate to AMM Pool detail page
-  const handleAMMSelect = (symbol: Symbol) => {
-    navigate(toPoolUrlPath(symbol.symbol))
-  }
-
-  // Navigate to CLOB Market trading page
-  const handleCLOBSelect = (symbol: Symbol) => {
-    navigate(toMarketUrlPath(symbol.symbol))
+  const handleSelect = (symbol: Symbol) => {
+    navigate(toSpotTradePath(symbol))
   }
 
   return (
     <div className="space-y-6 animate-fade-in">
-      {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-text-primary">Trade</h1>
+        <h1 className="text-2xl font-bold text-text-primary">Spot Markets</h1>
         <p className="text-text-secondary mt-1">
-          Select a market to start trading
+          Order book trading — select a pair to start
         </p>
       </div>
 
-      {/* Two Column Market Selection */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* AMM Pools */}
-        <Card>
-          <CardHeader
-            title="AMM Pools"
-            subtitle={`${ammSymbols.length} available pools`}
-          />
-          <div className="space-y-2 max-h-96 overflow-y-auto">
-            {ammSymbols.length > 0 ? (
-              ammSymbols.map((symbol) => (
-                <MarketCard
-                  key={symbol.symbol}
-                  symbol={symbol}
-                  isSelected={false}
-                  onSelect={() => handleAMMSelect(symbol)}
-                  variant="amm"
-                />
-              ))
-            ) : (
-              <p className="text-center text-text-tertiary py-4">No AMM pools available</p>
-            )}
-          </div>
-        </Card>
-
-        {/* Order Book Markets */}
-        <Card>
-          <CardHeader
-            title="Order Book Markets"
-            subtitle={`${clobSymbols.length} available pairs`}
-          />
-          <div className="space-y-2 max-h-96 overflow-y-auto">
-            {clobSymbols.length > 0 ? (
-              clobSymbols.map((symbol) => (
-                <MarketCard
-                  key={symbol.symbol}
-                  symbol={symbol}
-                  isSelected={false}
-                  onSelect={() => handleCLOBSelect(symbol)}
-                  variant="clob"
-                />
-              ))
-            ) : (
-              <p className="text-center text-text-tertiary py-4">No order book markets available</p>
-            )}
-          </div>
-        </Card>
-      </div>
+      <Card>
+        <CardHeader
+          title="Order Book Markets"
+          subtitle={`${spotMarkets.length} available pairs`}
+        />
+        <div className="space-y-2 max-h-[600px] overflow-y-auto">
+          {spotMarkets.length > 0 ? (
+            spotMarkets.map((symbol) => (
+              <button
+                key={symbol.symbol}
+                onClick={() => handleSelect(symbol)}
+                className="w-full p-3 rounded-lg border text-left transition-all bg-bg-tertiary border-border-default hover:border-border-hover"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-full bg-accent-blue/20 flex items-center justify-center">
+                      <span className="text-xs font-bold text-accent-blue">
+                        {symbol.base?.charAt(0)}
+                      </span>
+                    </div>
+                    <div>
+                      <p className="font-medium text-text-primary">{getDisplayName(symbol)}</p>
+                      <p className="text-xs text-text-tertiary">
+                        Order Book • {symbol.market?.toUpperCase() || 'SPOT'}
+                      </p>
+                    </div>
+                  </div>
+                  {symbol.current_price != null && (
+                    <span className="text-sm text-text-secondary font-mono">
+                      {Number(symbol.current_price).toFixed(4)}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))
+          ) : (
+            <p className="text-center text-text-tertiary py-8">No spot markets available</p>
+          )}
+        </div>
+      </Card>
     </div>
   )
 }

--- a/frontend/src/utils/market.ts
+++ b/frontend/src/utils/market.ts
@@ -164,3 +164,46 @@ export function groupSymbolsByEngine(symbols: Symbol[]): {
     clob: symbols.filter(s => s.engine_type === 1),
   }
 }
+
+// ── New simplified URL helpers (Market Taxonomy refactor) ──
+
+/**
+ * Build URL path for spot trading page.
+ * Returns: "/trade/spot/BASE-QUOTE"
+ */
+export function toSpotTradePath(symbol: Symbol | string): string {
+  if (typeof symbol === 'object') {
+    return `/trade/spot/${symbol.base}-${symbol.quote}`
+  }
+  const parts = parseSymbolToPath(symbol)
+  if (parts) return `/trade/spot/${parts.base}-${parts.quote}`
+  return `/trade/spot/${symbol}`
+}
+
+/**
+ * Build URL path for pool detail page (simplified).
+ * Returns: "/pools/BASE-QUOTE"
+ */
+export function toPoolPath(symbol: Symbol | string): string {
+  if (typeof symbol === 'object') {
+    return `/pools/${symbol.base}-${symbol.quote}`
+  }
+  const parts = parseSymbolToPath(symbol)
+  if (parts) return `/pools/${parts.base}-${parts.quote}`
+  return `/pools/${symbol}`
+}
+
+/**
+ * Parse simplified pair URL param (e.g. "BTC-USDT") into components.
+ * Infers settle=quote and market from context (default SPOT).
+ */
+export function parsePairParam(pair: string, market: string = 'SPOT'): SymbolPathComponents | null {
+  const parts = pair.split('-')
+  if (parts.length < 2) return null
+  return {
+    base: parts[0].toUpperCase(),
+    quote: parts[1].toUpperCase(),
+    settle: parts[1].toUpperCase(), // settle defaults to quote
+    market: market.toUpperCase(),
+  }
+}


### PR DESCRIPTION
## Summary
- **#61**: Refactor header navigation — Trade dropdown (Spot/Perp) + Pools link
- **#62**: Refactor routing — /trade/spot/:pair and /pools/:pair
- **#63**: Create Pools list page

## Architecture Change

The frontend now organizes markets by **user intent** instead of engine type:

| Section | Route | Engine | Purpose |
|---------|-------|--------|---------|
| **Trade → Spot** | `/trade/spot/:pair` | CLOB | Order book trading |
| **Trade → Perp** | Coming soon | CLOB + margin | Perpetual futures |
| **Pools** | `/pools/:pair` | AMM | Swap + LP management |

AMM is no longer under "Trade" — it has its own top-level "Pools" section.

## Changes

### Header (`Header.tsx`)
- Dashboard | **Trade** (dropdown: Spot, Perp) | **Pools** — three nav items
- Trade dropdown: Spot links to `/trade/spot`, Perp shows "Soon" badge
- Active state highlights correctly for `/trade/*` and `/pools/*` routes

### Routes (`App.tsx`)
- `/trade` → redirects to `/trade/spot`
- `/trade/spot` → CLOB spot markets list (was mixed AMM+CLOB)
- `/trade/spot/:pair` → Order book trading page (simplified URL: `BTC-USDT`)
- `/pools` → AMM pools list (new page)
- `/pools/:pair` → Pool detail + swap + LP (simplified URL: `VEGA-USDT`)
- Legacy `/market/:base/:quote/:settle/:market` → redirects to `/trade/spot`

### TradingPage → Spot Markets Only
- Removed AMM column — now only shows CLOB order book markets
- Navigates to `/trade/spot/BASE-QUOTE` format

### PoolsListPage (new)
- Grid of AMM pool cards with price and fee rate
- Navigates to `/pools/BASE-QUOTE` format

### URL Simplification
- Old: `/market/BTC/USDT/USDT/SPOT` → New: `/trade/spot/BTC-USDT`
- Old: `/pools/AMM-USDT-USDT-SPOT` → New: `/pools/VEGA-USDT`
- `parsePairParam()` infers settle=quote, market=SPOT from simplified pair

### Skills Updated
- `/fe` and `/be` skills now include Market Taxonomy guidelines

## Test plan
- [ ] Header shows Dashboard / Trade (dropdown) / Pools
- [ ] Trade → Spot shows only CLOB markets
- [ ] Clicking a spot market navigates to `/trade/spot/BASE-QUOTE` and opens order book
- [ ] Pools page shows AMM pools with price/fee metrics
- [ ] Clicking a pool navigates to `/pools/BASE-QUOTE` and opens pool detail
- [ ] Old URLs redirect gracefully
- [ ] Back buttons navigate to correct parent pages

Closes #61, Closes #62, Closes #63