### PR TITLE
Improve Settings JSON editor and Audit Log expandable rows

### DIFF
--- a/admin_dashboard/src/pages/AuditLogPage.tsx
+++ b/admin_dashboard/src/pages/AuditLogPage.tsx
@@ -15,11 +15,35 @@ interface AuditEntry {
 
 const PAGE_SIZE = 20
 
+// Summarize details into a short string for collapsed view
+function summarizeDetails(details: Record<string, unknown> | null): string {
+  if (!details) return '—'
+  const keys = Object.keys(details)
+  if (keys.length === 0) return '—'
+
+  // Common patterns
+  if ('old' in details && 'new' in details) {
+    return `${keys.length - 2 > 0 ? keys.length + ' fields' : 'value'} changed`
+  }
+  if (keys.length <= 2) {
+    return keys.map(k => `${k}: ${JSON.stringify(details[k])}`).join(', ')
+  }
+  return `${keys.length} fields`
+}
+
+// Render a value with appropriate formatting
+function renderValue(value: unknown): string {
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'object') return JSON.stringify(value, null, 2)
+  return String(value)
+}
+
 export function AuditLogPage() {
   const [entries, setEntries] = useState<AuditEntry[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [offset, setOffset] = useState(0)
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
 
   // Filters
   const [actionFilter, setActionFilter] = useState('')
@@ -50,6 +74,15 @@ export function AuditLogPage() {
   const handleFilter = () => {
     setOffset(0)
     loadAuditLog()
+  }
+
+  const toggleExpand = (id: number) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
   }
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
@@ -108,55 +141,126 @@ export function AuditLogPage() {
         <table className="w-full">
           <thead>
             <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
+              <th className="px-4 py-3 font-medium w-8"></th>
               <th className="px-4 py-3 font-medium">Time</th>
               <th className="px-4 py-3 font-medium">Admin</th>
               <th className="px-4 py-3 font-medium">Action</th>
               <th className="px-4 py-3 font-medium">Target</th>
-              <th className="px-4 py-3 font-medium">Details</th>
+              <th className="px-4 py-3 font-medium">Summary</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border-default">
             {loading ? (
               <tr>
-                <td colSpan={5} className="px-4 py-8 text-center">
+                <td colSpan={6} className="px-4 py-8 text-center">
                   <div className="inline-block w-5 h-5 border-2 border-text-tertiary border-t-accent-blue rounded-full animate-spin" />
                 </td>
               </tr>
             ) : entries.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-text-tertiary text-sm">
+                <td colSpan={6} className="px-4 py-8 text-center text-text-tertiary text-sm">
                   No audit log entries found.
                 </td>
               </tr>
             ) : (
-              entries.map((entry) => (
-                <tr key={entry.id} className="text-sm">
-                  <td className="px-4 py-3 text-text-tertiary text-xs whitespace-nowrap">
-                    {new Date(entry.created_at).toLocaleString()}
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    {entry.admin_name || entry.admin_email || entry.admin_id}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="px-2 py-0.5 text-xs rounded bg-bg-hover text-text-primary">
-                      {entry.action}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary text-xs">
-                    {entry.target_type && (
-                      <span className="text-text-tertiary">{entry.target_type}:</span>
-                    )}{' '}
-                    {entry.target_id || '—'}
-                  </td>
-                  <td className="px-4 py-3 max-w-xs">
-                    {entry.details ? (
-                      <code className="text-xs text-text-tertiary break-all">
-                        {JSON.stringify(entry.details)}
-                      </code>
-                    ) : '—'}
-                  </td>
-                </tr>
-              ))
+              entries.map((entry) => {
+                const isExpanded = expandedIds.has(entry.id)
+                const hasDetails = entry.details && Object.keys(entry.details).length > 0
+
+                return (
+                  <tr
+                    key={entry.id}
+                    className={`text-sm ${hasDetails ? 'cursor-pointer hover:bg-bg-tertiary/30' : ''}`}
+                    onClick={() => hasDetails && toggleExpand(entry.id)}
+                  >
+                    <td colSpan={6} className="p-0">
+                      {/* Row content */}
+                      <div className="flex items-center px-4 py-3">
+                        {/* Expand arrow */}
+                        <div className="w-8 flex-shrink-0">
+                          {hasDetails && (
+                            <span className={`text-text-tertiary text-xs transition-transform inline-block ${isExpanded ? 'rotate-90' : ''}`}>
+                              ▶
+                            </span>
+                          )}
+                        </div>
+                        {/* Time */}
+                        <div className="w-40 flex-shrink-0 text-text-tertiary text-xs whitespace-nowrap">
+                          {new Date(entry.created_at).toLocaleString()}
+                        </div>
+                        {/* Admin */}
+                        <div className="w-32 flex-shrink-0 text-text-secondary truncate">
+                          {entry.admin_name || entry.admin_email || entry.admin_id}
+                        </div>
+                        {/* Action */}
+                        <div className="w-40 flex-shrink-0">
+                          <span className="px-2 py-0.5 text-xs rounded bg-bg-hover text-text-primary">
+                            {entry.action}
+                          </span>
+                        </div>
+                        {/* Target */}
+                        <div className="w-32 flex-shrink-0 text-text-secondary text-xs">
+                          {entry.target_type && (
+                            <span className="text-text-tertiary">{entry.target_type}:</span>
+                          )}{' '}
+                          {entry.target_id || '—'}
+                        </div>
+                        {/* Summary */}
+                        <div className="flex-1 text-text-tertiary text-xs truncate">
+                          {summarizeDetails(entry.details)}
+                        </div>
+                      </div>
+
+                      {/* Expanded details */}
+                      {isExpanded && entry.details && (
+                        <div className="px-4 pb-4 pl-12">
+                          <div className="bg-bg-tertiary rounded-md p-4 space-y-3">
+                            {/* Check for old/new pattern */}
+                            {'old' in entry.details && 'new' in entry.details ? (
+                              <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                  <p className="text-xs font-medium text-accent-red mb-2">Old Value</p>
+                                  <pre className="text-xs font-mono text-text-secondary whitespace-pre-wrap bg-accent-red/5 rounded p-2 border border-accent-red/10">
+                                    {renderValue(entry.details.old)}
+                                  </pre>
+                                </div>
+                                <div>
+                                  <p className="text-xs font-medium text-accent-green mb-2">New Value</p>
+                                  <pre className="text-xs font-mono text-text-secondary whitespace-pre-wrap bg-accent-green/5 rounded p-2 border border-accent-green/10">
+                                    {renderValue(entry.details.new)}
+                                  </pre>
+                                </div>
+                                {/* Other fields besides old/new */}
+                                {Object.entries(entry.details)
+                                  .filter(([k]) => k !== 'old' && k !== 'new')
+                                  .map(([key, val]) => (
+                                    <div key={key} className="col-span-2">
+                                      <span className="text-xs text-text-tertiary">{key}:</span>{' '}
+                                      <span className="text-xs text-text-primary font-mono">{renderValue(val)}</span>
+                                    </div>
+                                  ))
+                                }
+                              </div>
+                            ) : (
+                              /* Generic key-value display */
+                              <div className="space-y-1.5">
+                                {Object.entries(entry.details).map(([key, val]) => (
+                                  <div key={key} className="flex gap-3">
+                                    <span className="text-xs text-text-tertiary min-w-[80px]">{key}:</span>
+                                    <span className="text-xs text-text-primary font-mono break-all">
+                                      {renderValue(val)}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })
             )}
           </tbody>
         </table>

--- a/admin_dashboard/src/pages/SettingsPage.tsx
+++ b/admin_dashboard/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { AdminService } from '@/api/services/AdminService'
 
 interface Setting {
@@ -29,6 +29,17 @@ export function SettingsPage() {
 
   useEffect(() => { loadSettings() }, [loadSettings])
 
+  // JSON validation
+  const jsonError = useMemo(() => {
+    if (!editValue) return null
+    try {
+      JSON.parse(editValue)
+      return null
+    } catch (e) {
+      return (e as Error).message
+    }
+  }, [editValue])
+
   const handleEdit = (setting: Setting) => {
     setEditingKey(setting.key)
     setEditValue(JSON.stringify(setting.value, null, 2))
@@ -40,7 +51,17 @@ export function SettingsPage() {
     setEditValue('')
   }
 
+  const handleFormat = () => {
+    try {
+      const parsed = JSON.parse(editValue)
+      setEditValue(JSON.stringify(parsed, null, 2))
+    } catch {
+      // Can't format invalid JSON
+    }
+  }
+
   const handleSave = async (key: string) => {
+    if (jsonError) return
     setSaving(true)
     setMessage(null)
     try {
@@ -58,6 +79,9 @@ export function SettingsPage() {
       setSaving(false)
     }
   }
+
+  // Count lines for line numbers
+  const lineCount = editValue.split('\n').length
 
   if (loading) {
     return (
@@ -82,71 +106,104 @@ export function SettingsPage() {
         </div>
       )}
 
-      <div className="border border-border-default rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead>
-            <tr className="text-left text-xs text-text-tertiary uppercase tracking-wide border-b border-border-default bg-bg-secondary">
-              <th className="px-4 py-3 font-medium">Key</th>
-              <th className="px-4 py-3 font-medium">Value</th>
-              <th className="px-4 py-3 font-medium">Description</th>
-              <th className="px-4 py-3 font-medium">Updated</th>
-              <th className="px-4 py-3 font-medium text-right">Action</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border-default">
-            {settings.map((s) => (
-              <tr key={s.key} className="text-sm">
-                <td className="px-4 py-3 font-mono text-text-primary">{s.key}</td>
-                <td className="px-4 py-3 max-w-xs">
-                  {editingKey === s.key ? (
+      <div className="space-y-4">
+        {settings.map((s) => (
+          <div key={s.key} className="border border-border-default rounded-lg overflow-hidden">
+            {/* Setting header */}
+            <div className="flex items-center justify-between px-4 py-3 bg-bg-secondary">
+              <div>
+                <span className="font-mono text-sm text-text-primary font-medium">{s.key}</span>
+                {s.description && (
+                  <p className="text-xs text-text-tertiary mt-0.5">{s.description}</p>
+                )}
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-text-tertiary">
+                  {new Date(s.updated_at).toLocaleString()}
+                </span>
+                {editingKey !== s.key && (
+                  <button
+                    onClick={() => handleEdit(s)}
+                    className="px-3 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md hover:border-border-hover"
+                  >
+                    Edit
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Value display / editor */}
+            <div className="px-4 py-3">
+              {editingKey === s.key ? (
+                <div>
+                  {/* Editor with line numbers */}
+                  <div className={`flex rounded-md border overflow-hidden ${
+                    jsonError ? 'border-accent-red' : 'border-border-default focus-within:border-accent-blue'
+                  }`}>
+                    {/* Line numbers */}
+                    <div className="bg-bg-tertiary px-2 py-3 text-right select-none border-r border-border-default">
+                      {Array.from({ length: lineCount }, (_, i) => (
+                        <div key={i} className="text-xs text-text-tertiary font-mono leading-5">
+                          {i + 1}
+                        </div>
+                      ))}
+                    </div>
+                    {/* Textarea */}
                     <textarea
                       value={editValue}
                       onChange={(e) => setEditValue(e.target.value)}
-                      rows={4}
-                      className="w-full px-3 py-2 bg-bg-tertiary border border-border-default rounded-md text-text-primary font-mono text-xs focus:outline-none focus:border-accent-blue"
+                      rows={Math.max(lineCount, 4)}
+                      spellCheck={false}
+                      className="flex-1 px-3 py-3 bg-bg-primary text-text-primary font-mono text-xs leading-5 resize-none focus:outline-none"
                     />
-                  ) : (
-                    <code className="text-xs text-text-secondary break-all">
-                      {JSON.stringify(s.value)}
-                    </code>
+                  </div>
+
+                  {/* Validation error */}
+                  {jsonError && (
+                    <div className="mt-2 px-3 py-2 bg-accent-red/10 border border-accent-red/20 rounded-md">
+                      <p className="text-xs text-accent-red font-mono">{jsonError}</p>
+                    </div>
                   )}
-                </td>
-                <td className="px-4 py-3 text-text-secondary">{s.description || '—'}</td>
-                <td className="px-4 py-3 text-text-tertiary text-xs">
-                  {new Date(s.updated_at).toLocaleString()}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  {editingKey === s.key ? (
-                    <div className="flex gap-2 justify-end">
-                      <button
-                        onClick={() => handleSave(s.key)}
-                        disabled={saving}
-                        className="px-3 py-1 text-xs bg-accent-blue text-white rounded-md hover:bg-accent-blue/80 disabled:opacity-50"
-                      >
-                        {saving ? 'Saving...' : 'Save'}
-                      </button>
+
+                  {/* Actions */}
+                  <div className="flex items-center justify-between mt-3">
+                    <button
+                      onClick={handleFormat}
+                      className="text-xs text-text-tertiary hover:text-accent-blue"
+                    >
+                      Format JSON
+                    </button>
+                    <div className="flex gap-2">
                       <button
                         onClick={handleCancel}
-                        className="px-3 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md"
+                        className="px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md"
                       >
                         Cancel
                       </button>
+                      <button
+                        onClick={() => handleSave(s.key)}
+                        disabled={saving || !!jsonError}
+                        className="px-4 py-1.5 text-xs bg-accent-blue text-white rounded-md hover:bg-accent-blue/80 disabled:opacity-40"
+                      >
+                        {saving ? 'Saving...' : 'Save'}
+                      </button>
                     </div>
-                  ) : (
-                    <button
-                      onClick={() => handleEdit(s)}
-                      className="px-3 py-1 text-xs text-text-secondary hover:text-text-primary border border-border-default rounded-md hover:border-border-hover"
-                    >
-                      Edit
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                  </div>
+                </div>
+              ) : (
+                /* Read-only pretty display */
+                <pre className="text-xs text-text-secondary font-mono whitespace-pre-wrap leading-5">
+                  {JSON.stringify(s.value, null, 2)}
+                </pre>
+              )}
+            </div>
+          </div>
+        ))}
+
         {settings.length === 0 && (
-          <div className="text-center py-8 text-text-tertiary text-sm">No settings found.</div>
+          <div className="text-center py-8 text-text-tertiary text-sm border border-border-default rounded-lg">
+            No settings found.
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **#75**: Settings page — pretty JSON editor with validation
- **#76**: Audit log — expandable rows with formatted diff

## Changes

### Settings Page
- Card-based layout per setting (was table rows)
- Read-only: pretty-printed JSON with indentation
- Edit mode: editor with line numbers + monospace font
- Real-time validation: red border + error when JSON invalid
- Save disabled when invalid (no more accidental broken saves)
- "Format JSON" button to auto-indent messy input

### Audit Log
- Expandable rows: ▶ arrow, click to toggle
- Collapsed: summary text ("value changed", "3 fields")
- Expanded: formatted details in bg-tertiary card
- Old/new diff: side-by-side with red (old) / green (new) backgrounds
- Generic key-value display for non-diff details
- Multiple rows expandable simultaneously

## Test plan
- [ ] Settings: values display with proper indentation
- [ ] Settings: edit mode shows line numbers
- [ ] Settings: type invalid JSON → red border + error message + Save disabled
- [ ] Settings: click Format JSON → auto-indents
- [ ] Settings: save valid JSON → success message
- [ ] Audit log: rows collapsed by default with summary
- [ ] Audit log: click row → expands to show details
- [ ] Audit log: update actions show old/new side-by-side diff
- [ ] Audit log: click again → collapses

Closes #75, Closes #76