### PR TITLE
Implement kline system with pre-computed candles and 24h ticker

### DIFF
--- a/backend/engines/base_engine.py
+++ b/backend/engines/base_engine.py
@@ -294,4 +294,17 @@ class BaseEngine(ABC):
             counterparty_user_id,  # Maps to counterparty column (NULL for AMM trades)
         )
 
+        # Upsert kline candles for all 8 intervals
+        try:
+            from backend.services.kline import upsert_klines
+            await upsert_klines(
+                symbol_id=self.symbol_config["symbol_id"],
+                engine_type=self.engine_type.value,
+                price=price,
+                quantity=quantity,
+                quote_amount=quote_amount,
+            )
+        except Exception as e:
+            print(f"[WARN] Failed to upsert klines: {e}")
+
         return result["trade_id"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,6 +35,13 @@ async def lifespan(app: FastAPI):
     init_ws_manager()
     print("WebSocket manager initialized.")
 
+    # Backfill kline gaps from downtime
+    try:
+        from backend.services.kline import kline_backfill
+        await kline_backfill()
+    except Exception as e:
+        print(f"[WARN] Kline backfill failed: {e}")
+
     yield
 
     # Shutdown

--- a/backend/models/admin.py
+++ b/backend/models/admin.py
@@ -61,6 +61,7 @@ class CreateSymbolRequest(BaseModel):
     max_trade_amount: Decimal = Field(default=Decimal("1000000"), description="Maximum trade amount")
     price_precision: int = Field(default=8, description="Price decimal precision")
     quantity_precision: int = Field(default=8, description="Quantity decimal precision")
+    init_price: Optional[Decimal] = Field(None, gt=0, description="Initial reference price for CLOB kline chart (optional)")
 
     @field_validator("symbol", "base_asset", "quote_asset", "market", "settle")
     @classmethod

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -38,10 +38,23 @@ async def get_symbol_engines(
 @router.get("/klines", response_model=APIResponse)
 async def get_klines(
     symbol: str = Query(..., description="Symbol (e.g. BTC/USDT-USDT:SPOT)"),
-    interval: str = Query("1h", description="Candle interval: 1m, 5m, 15m, 1h, 4h, 1d"),
+    interval: str = Query("1h", description="Candle interval: 1m, 5m, 15m, 1h, 4h, 8h, 1d, 1M"),
     engine_type: Optional[int] = Query(None, description="Engine type: 0=AMM, 1=CLOB"),
     limit: int = Query(100, ge=1, le=500, description="Number of candles to return"),
 ):
-    """Get OHLCV kline data with forward-fill for empty intervals."""
+    """Get OHLCV kline data from pre-computed klines table."""
     data = await market_service.get_klines(symbol, interval, engine_type, limit)
+    return APIResponse(success=True, data=data)
+
+
+@router.get("/ticker", response_model=APIResponse)
+async def get_ticker(
+    symbol: Optional[str] = Query(None, description="Symbol. If omitted, returns all tickers."),
+    engine_type: Optional[int] = Query(None, description="Engine type: 0=AMM, 1=CLOB"),
+):
+    """Get 24h ticker stats. Single symbol or all active symbols."""
+    if symbol:
+        data = await market_service.get_ticker(symbol, engine_type)
+    else:
+        data = await market_service.get_all_tickers()
     return APIResponse(success=True, data=data)

--- a/backend/services/admin.py
+++ b/backend/services/admin.py
@@ -60,6 +60,16 @@ async def create_symbol(request: CreateSymbolRequest, router: EngineRouter) -> d
     )
 
     router.invalidate_cache(request.symbol)
+
+    # Write initial klines if init_price is provided (CLOB symbols)
+    if request.init_price is not None:
+        from backend.services.kline import write_initial_klines
+        await write_initial_klines(
+            symbol_id=result["symbol_id"],
+            engine_type=request.engine_type.value,
+            price=request.init_price,
+        )
+
     return result
 
 
@@ -127,6 +137,16 @@ async def create_pool(request: CreatePoolRequest, router: EngineRouter) -> dict:
     )
 
     router.invalidate_cache(request.symbol)
+
+    # Write initial klines from AMM pool price (reserve_quote / reserve_base)
+    if request.initial_reserve_base > 0:
+        amm_price = request.initial_reserve_quote / request.initial_reserve_base
+        from backend.services.kline import write_initial_klines
+        await write_initial_klines(
+            symbol_id=symbol_result["symbol_id"],
+            engine_type=EngineType.AMM.value,
+            price=amm_price,
+        )
 
     return {
         "symbol": symbol_result,

--- a/backend/services/kline.py
+++ b/backend/services/kline.py
@@ -1,0 +1,291 @@
+"""
+Kline service — pre-computed candlestick management.
+
+Handles:
+- Trade-time upsert: 8 intervals updated per trade
+- Startup backfill: forward-fill gaps on server restart
+- Initial klines: written on symbol/pool creation
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional
+
+from backend.core.db_manager import get_db
+
+# Supported intervals and their duration in seconds
+SUPPORTED_INTERVALS = {
+    "1m": 60,
+    "5m": 300,
+    "15m": 900,
+    "1h": 3600,
+    "4h": 14400,
+    "8h": 28800,
+    "1d": 86400,
+    "1M": None,  # handled specially (calendar month)
+}
+
+INTERVAL_SECONDS = {k: v for k, v in SUPPORTED_INTERVALS.items() if v is not None}
+
+
+def _floor_to_interval(ts: datetime, interval: str) -> datetime:
+    """Floor a timestamp to the start of its interval bucket."""
+    ts_utc = ts.astimezone(timezone.utc) if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+    if interval == "1M":
+        return ts_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    seconds = INTERVAL_SECONDS[interval]
+    epoch = int(ts_utc.timestamp())
+    floored_epoch = (epoch // seconds) * seconds
+    return datetime.fromtimestamp(floored_epoch, tz=timezone.utc)
+
+
+async def upsert_klines(
+    symbol_id: int,
+    engine_type: int,
+    price: Decimal,
+    quantity: Decimal,
+    quote_amount: Decimal,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """
+    Upsert kline candles for all 8 intervals after a trade.
+    Uses INSERT ON CONFLICT DO UPDATE for atomic upsert.
+    """
+    db = get_db()
+    ts = timestamp or datetime.now(timezone.utc)
+
+    for interval in SUPPORTED_INTERVALS:
+        open_time = _floor_to_interval(ts, interval)
+
+        await db.execute(
+            """
+            INSERT INTO klines (symbol_id, engine_type, interval, open_time, open, high, low, close, volume, quote_volume, trade_count)
+            VALUES ($1, $2, $3, $4, $5, $5, $5, $5, $6, $7, 1)
+            ON CONFLICT (symbol_id, engine_type, interval, open_time) DO UPDATE SET
+                high = GREATEST(klines.high, EXCLUDED.high),
+                low = LEAST(klines.low, EXCLUDED.low),
+                close = EXCLUDED.close,
+                volume = klines.volume + EXCLUDED.volume,
+                quote_volume = klines.quote_volume + EXCLUDED.quote_volume,
+                trade_count = klines.trade_count + 1
+            """,
+            symbol_id,
+            engine_type,
+            interval,
+            open_time,
+            price,
+            quantity,
+            quote_amount,
+        )
+
+
+async def write_initial_klines(
+    symbol_id: int,
+    engine_type: int,
+    price: Decimal,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """
+    Write initial kline candles for all 8 intervals when creating a symbol/pool.
+    Sets OHLCV = price with volume=0, trade_count=0.
+    """
+    db = get_db()
+    ts = timestamp or datetime.now(timezone.utc)
+
+    for interval in SUPPORTED_INTERVALS:
+        open_time = _floor_to_interval(ts, interval)
+
+        await db.execute(
+            """
+            INSERT INTO klines (symbol_id, engine_type, interval, open_time, open, high, low, close, volume, quote_volume, trade_count)
+            VALUES ($1, $2, $3, $4, $5, $5, $5, $5, 0, 0, 0)
+            ON CONFLICT (symbol_id, engine_type, interval, open_time) DO NOTHING
+            """,
+            symbol_id,
+            engine_type,
+            interval,
+            open_time,
+            price,
+        )
+
+
+async def kline_backfill() -> None:
+    """
+    On server startup, scan all symbol × interval for gaps and forward-fill
+    with flat candles (OHLCV = prev close, volume=0).
+    """
+    db = get_db()
+    now = datetime.now(timezone.utc)
+
+    # Get all active symbols with their engine types
+    symbols = await db.read(
+        "SELECT symbol_id, engine_type FROM symbol_configs WHERE is_active = TRUE"
+    )
+
+    total_filled = 0
+
+    for sym in symbols:
+        symbol_id = sym["symbol_id"]
+        engine_type = sym["engine_type"]
+
+        for interval, seconds in INTERVAL_SECONDS.items():
+            # Get the last kline for this symbol + interval
+            last = await db.read_one(
+                """
+                SELECT open_time, close FROM klines
+                WHERE symbol_id = $1 AND engine_type = $2 AND interval = $3
+                ORDER BY open_time DESC LIMIT 1
+                """,
+                symbol_id, engine_type, interval,
+            )
+
+            if not last:
+                continue
+
+            last_open = last["open_time"]
+            if last_open.tzinfo is None:
+                last_open = last_open.replace(tzinfo=timezone.utc)
+            prev_close = last["close"]
+
+            # Generate missing candles from last_open + interval to now
+            current = datetime.fromtimestamp(
+                int(last_open.timestamp()) + seconds, tz=timezone.utc
+            )
+
+            batch_values = []
+            while current <= now:
+                batch_values.append((symbol_id, engine_type, interval, current, prev_close))
+                current = datetime.fromtimestamp(
+                    int(current.timestamp()) + seconds, tz=timezone.utc
+                )
+
+            # Batch insert forward-fill candles
+            for sv in batch_values:
+                await db.execute(
+                    """
+                    INSERT INTO klines (symbol_id, engine_type, interval, open_time, open, high, low, close, volume, quote_volume, trade_count)
+                    VALUES ($1, $2, $3, $4, $5, $5, $5, $5, 0, 0, 0)
+                    ON CONFLICT (symbol_id, engine_type, interval, open_time) DO NOTHING
+                    """,
+                    sv[0], sv[1], sv[2], sv[3], sv[4],
+                )
+
+            total_filled += len(batch_values)
+
+        # Handle 1M interval separately
+        last_month = await db.read_one(
+            """
+            SELECT open_time, close FROM klines
+            WHERE symbol_id = $1 AND engine_type = $2 AND interval = '1M'
+            ORDER BY open_time DESC LIMIT 1
+            """,
+            symbol_id, engine_type,
+        )
+
+        if last_month:
+            last_open = last_month["open_time"]
+            if last_open.tzinfo is None:
+                last_open = last_open.replace(tzinfo=timezone.utc)
+            prev_close = last_month["close"]
+
+            # Advance month by month
+            current_year = last_open.year
+            current_month = last_open.month + 1
+            if current_month > 12:
+                current_year += 1
+                current_month = 1
+
+            while datetime(current_year, current_month, 1, tzinfo=timezone.utc) <= now:
+                open_time = datetime(current_year, current_month, 1, tzinfo=timezone.utc)
+                await db.execute(
+                    """
+                    INSERT INTO klines (symbol_id, engine_type, interval, open_time, open, high, low, close, volume, quote_volume, trade_count)
+                    VALUES ($1, $2, '1M', $3, $4, $4, $4, $4, 0, 0, 0)
+                    ON CONFLICT (symbol_id, engine_type, interval, open_time) DO NOTHING
+                    """,
+                    symbol_id, engine_type, open_time, prev_close,
+                )
+                total_filled += 1
+                current_month += 1
+                if current_month > 12:
+                    current_year += 1
+                    current_month = 1
+
+    print(f"Kline backfill complete: {total_filled} candles filled.")
+
+
+async def get_klines(
+    symbol_id: int,
+    engine_type: int,
+    interval: str,
+    limit: int = 100,
+) -> List[dict]:
+    """Get klines from pre-computed table."""
+    if interval not in SUPPORTED_INTERVALS:
+        return []
+
+    db = get_db()
+    rows = await db.read(
+        """
+        SELECT open_time, open, high, low, close, volume, quote_volume, trade_count
+        FROM klines
+        WHERE symbol_id = $1 AND engine_type = $2 AND interval = $3
+        ORDER BY open_time DESC
+        LIMIT $4
+        """,
+        symbol_id, engine_type, interval, limit,
+    )
+
+    # Reverse to ascending order for chart rendering
+    rows.reverse()
+    return rows
+
+
+async def get_24h_ticker(symbol_id: int, engine_type: int) -> dict:
+    """
+    Get 24h ticker stats from 1h klines (24 rows).
+    Returns: open_24h, high_24h, low_24h, close (current), volume_24h, quote_volume_24h, price_change, price_change_pct.
+    """
+    db = get_db()
+
+    rows = await db.read(
+        """
+        SELECT open_time, open, high, low, close, volume, quote_volume
+        FROM klines
+        WHERE symbol_id = $1 AND engine_type = $2 AND interval = '1h'
+        ORDER BY open_time DESC
+        LIMIT 24
+        """,
+        symbol_id, engine_type,
+    )
+
+    if not rows:
+        return {
+            "open_24h": 0, "high_24h": 0, "low_24h": 0, "close": 0,
+            "volume_24h": 0, "quote_volume_24h": 0,
+            "price_change": 0, "price_change_pct": 0,
+        }
+
+    # rows are DESC, so rows[0] is latest, rows[-1] is oldest
+    current_close = float(rows[0]["close"])
+    open_24h = float(rows[-1]["open"])
+    high_24h = max(float(r["high"]) for r in rows)
+    low_24h = min(float(r["low"]) for r in rows)
+    volume_24h = sum(float(r["volume"]) for r in rows)
+    quote_volume_24h = sum(float(r["quote_volume"]) for r in rows)
+
+    price_change = current_close - open_24h
+    price_change_pct = (price_change / open_24h * 100) if open_24h != 0 else 0
+
+    return {
+        "open_24h": open_24h,
+        "high_24h": high_24h,
+        "low_24h": low_24h,
+        "close": current_close,
+        "volume_24h": volume_24h,
+        "quote_volume_24h": quote_volume_24h,
+        "price_change": price_change,
+        "price_change_pct": round(price_change_pct, 4),
+    }

--- a/backend/services/market.py
+++ b/backend/services/market.py
@@ -143,87 +143,96 @@ async def get_klines(
     engine_type: Optional[int] = None,
     limit: int = 100,
 ) -> dict:
-    """Get OHLCV kline data with forward-fill for empty intervals."""
-    if interval not in KLINE_INTERVALS:
+    """Get OHLCV kline data from pre-computed klines table."""
+    from backend.services.kline import SUPPORTED_INTERVALS, get_klines as kline_get
+
+    if interval not in SUPPORTED_INTERVALS:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid interval '{interval}'. Valid: {', '.join(KLINE_INTERVALS.keys())}",
+            detail=f"Invalid interval '{interval}'. Valid: {', '.join(SUPPORTED_INTERVALS.keys())}",
         )
 
-    interval_seconds = KLINE_INTERVALS[interval]
     db = get_db()
     symbol_upper = symbol.upper()
 
-    et_filter = ""
-    params: list = [symbol_upper, interval_seconds, limit]
+    # Resolve symbol_id and engine_type
     if engine_type is not None:
-        et_filter = "AND t.engine_type = $4"
-        params.append(engine_type)
+        sym = await db.read_one(
+            "SELECT symbol_id FROM symbol_configs WHERE symbol = $1 AND engine_type = $2",
+            symbol_upper, engine_type,
+        )
+    else:
+        sym = await db.read_one(
+            "SELECT symbol_id, engine_type FROM symbol_configs WHERE symbol = $1 AND is_active = TRUE LIMIT 1",
+            symbol_upper,
+        )
+        if sym:
+            engine_type = sym["engine_type"]
 
-    raw_candles = await db.read(
-        f"""
-        SELECT
-            (EXTRACT(EPOCH FROM t.created_at)::bigint / $2) * $2 AS bucket,
-            (array_agg(t.price ORDER BY t.created_at ASC))[1] AS open,
-            MAX(t.price) AS high,
-            MIN(t.price) AS low,
-            (array_agg(t.price ORDER BY t.created_at DESC))[1] AS close,
-            SUM(t.quantity) AS volume,
-            SUM(t.quote_amount) AS quote_volume,
-            COUNT(*) AS trade_count
-        FROM trades t
-        JOIN symbol_configs sc USING (symbol_id)
-        WHERE sc.symbol = $1
-        AND t.status = 1
-        {et_filter}
-        GROUP BY bucket
-        ORDER BY bucket DESC
-        LIMIT $3
-        """,
-        *params,
-    )
-
-    if not raw_candles:
+    if not sym:
         return {"symbol": symbol_upper, "interval": interval, "klines": []}
 
-    raw_candles.reverse()
+    rows = await kline_get(sym["symbol_id"], engine_type, interval, limit)
 
-    candle_map = {}
-    for c in raw_candles:
-        candle_map[int(c["bucket"])] = c
-
-    first_bucket = int(raw_candles[0]["bucket"])
-    last_bucket = int(raw_candles[-1]["bucket"])
-
-    klines = []
-    prev_close = raw_candles[0]["close"]
-
-    bucket = first_bucket
-    while bucket <= last_bucket:
-        if bucket in candle_map:
-            c = candle_map[bucket]
-            klines.append({
-                "time": bucket,
-                "open": c["open"],
-                "high": c["high"],
-                "low": c["low"],
-                "close": c["close"],
-                "volume": c["volume"],
-                "quote_volume": c["quote_volume"],
-                "trade_count": c["trade_count"],
-            })
-            prev_close = c["close"]
-        else:
-            klines.append({
-                "time": bucket,
-                "open": prev_close,
-                "high": prev_close,
-                "low": prev_close,
-                "close": prev_close,
-                "volume": 0,
-                "quote_volume": 0,
-                "trade_count": 0,
-            })
-        bucket += interval_seconds
+    klines = [
+        {
+            "time": int(r["open_time"].timestamp()) if hasattr(r["open_time"], "timestamp") else r["open_time"],
+            "open": r["open"],
+            "high": r["high"],
+            "low": r["low"],
+            "close": r["close"],
+            "volume": r["volume"],
+            "quote_volume": r["quote_volume"],
+            "trade_count": r["trade_count"],
+        }
+        for r in rows
+    ]
 
     return {"symbol": symbol_upper, "interval": interval, "klines": klines}
+
+
+async def get_ticker(symbol: str, engine_type: Optional[int] = None) -> dict:
+    """Get 24h ticker stats from 1h klines (24 rows)."""
+    from backend.services.kline import get_24h_ticker
+
+    db = get_db()
+    symbol_upper = symbol.upper()
+
+    if engine_type is not None:
+        sym = await db.read_one(
+            "SELECT symbol_id FROM symbol_configs WHERE symbol = $1 AND engine_type = $2",
+            symbol_upper, engine_type,
+        )
+    else:
+        sym = await db.read_one(
+            "SELECT symbol_id, engine_type FROM symbol_configs WHERE symbol = $1 AND is_active = TRUE LIMIT 1",
+            symbol_upper,
+        )
+        if sym:
+            engine_type = sym["engine_type"]
+
+    if not sym:
+        raise HTTPException(status_code=404, detail=f"Symbol '{symbol}' not found")
+
+    ticker = await get_24h_ticker(sym["symbol_id"], engine_type)
+    ticker["symbol"] = symbol_upper
+    return ticker
+
+
+async def get_all_tickers() -> list:
+    """Get 24h ticker stats for all active symbols."""
+    from backend.services.kline import get_24h_ticker
+
+    db = get_db()
+    symbols = await db.read(
+        "SELECT symbol_id, symbol, engine_type FROM symbol_configs WHERE is_active = TRUE"
+    )
+
+    tickers = []
+    for sym in symbols:
+        ticker = await get_24h_ticker(sym["symbol_id"], sym["engine_type"])
+        ticker["symbol"] = sym["symbol"]
+        ticker["engine_type"] = sym["engine_type"]
+        tickers.append(ticker)
+
+    return tickers

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -377,6 +377,29 @@ CREATE INDEX idx_audit_logs_created_at ON admin_audit_logs(created_at);
 CREATE INDEX idx_audit_logs_action ON admin_audit_logs(action);
 
 -- =====================================================
+-- KLINES TABLE (pre-computed candlestick data)
+-- =====================================================
+-- Upserted on every trade for all 8 intervals.
+-- Forward-filled on server startup to eliminate gaps.
+CREATE TABLE IF NOT EXISTS klines (
+    symbol_id INTEGER NOT NULL REFERENCES symbol_configs(symbol_id),
+    engine_type SMALLINT NOT NULL,           -- 0=AMM, 1=CLOB
+    interval VARCHAR(10) NOT NULL,           -- '1m','5m','15m','1h','4h','8h','1d','1M'
+    open_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    open DECIMAL(36, 18) NOT NULL,
+    high DECIMAL(36, 18) NOT NULL,
+    low DECIMAL(36, 18) NOT NULL,
+    close DECIMAL(36, 18) NOT NULL,
+    volume DECIMAL(36, 18) NOT NULL DEFAULT 0,
+    quote_volume DECIMAL(36, 18) NOT NULL DEFAULT 0,
+    trade_count INTEGER NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (symbol_id, engine_type, interval, open_time)
+);
+
+CREATE INDEX idx_klines_query ON klines(symbol_id, engine_type, interval, open_time DESC);
+
+-- =====================================================
 -- HELPER FUNCTIONS
 -- =====================================================
 


### PR DESCRIPTION
## Summary
- Implement pre-computed kline system with trade-time upsert for all 8 intervals
- Add 24h ticker endpoint using 1h klines (24 rows, not 1440)
- Add startup backfill to eliminate gaps from server downtime
- Support CLOB `init_price` and AMM pool initial klines

## New files
| File | Purpose |
|------|---------|
| `backend/services/kline.py` | Kline upsert, backfill, query, ticker calculation |

## New endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/market/ticker` | 24h ticker stats (single symbol or all) |

## Modified files
| File | Change |
|------|--------|
| `database/schema.sql` | New `klines` table with composite PK + query index |
| `backend/engines/base_engine.py` | Call `upsert_klines()` after every `record_trade()` |
| `backend/main.py` | Call `kline_backfill()` in lifespan startup |
| `backend/models/admin.py` | Add `init_price` to `CreateSymbolRequest` |
| `backend/services/admin.py` | Write initial klines on `create_symbol` (with init_price) and `create_pool` |
| `backend/services/market.py` | Rewrite `get_klines()` to read from klines table; add `get_ticker()` + `get_all_tickers()` |
| `backend/routers/market.py` | Add `/ticker` endpoint, update `/klines` description |

## Architecture

```
Trade → record_trade() → upsert_klines() (8 intervals, ~1-4ms)

Server startup → kline_backfill() (forward-fill gaps with prev close, volume=0)

create_symbol(init_price=50) → write_initial_klines() (8 intervals, OHLCV=50)
create_pool(reserves) → write_initial_klines() (price = quote/base)

GET /market/klines?interval=4h → SELECT from klines table (no aggregation)
GET /market/ticker → aggregate 24 rows of 1h klines
```

## Supported intervals
`1m`, `5m`, `15m`, `1h`, `4h`, `8h`, `1d`, `1M`

## Database migration
Run as database owner:
```sql
CREATE TABLE IF NOT EXISTS klines (
    symbol_id INTEGER NOT NULL REFERENCES symbol_configs(symbol_id),
    engine_type SMALLINT NOT NULL,
    interval VARCHAR(10) NOT NULL,
    open_time TIMESTAMP WITH TIME ZONE NOT NULL,
    open DECIMAL(36, 18) NOT NULL,
    high DECIMAL(36, 18) NOT NULL,
    low DECIMAL(36, 18) NOT NULL,
    close DECIMAL(36, 18) NOT NULL,
    volume DECIMAL(36, 18) NOT NULL DEFAULT 0,
    quote_volume DECIMAL(36, 18) NOT NULL DEFAULT 0,
    trade_count INTEGER NOT NULL DEFAULT 0,
    PRIMARY KEY (symbol_id, engine_type, interval, open_time)
);
CREATE INDEX idx_klines_query ON klines(symbol_id, engine_type, interval, open_time DESC);
```

## Test plan
- [ ] Trade upserts klines for all 8 intervals
- [ ] GET /market/klines reads from klines table
- [ ] GET /market/ticker returns 24h stats
- [ ] GET /market/ticker with no symbol returns all tickers
- [ ] create_symbol with init_price writes initial klines
- [ ] create_pool writes initial klines from reserve price
- [ ] Server restart backfills gaps correctly
- [ ] Kline upsert failure does not break trade execution

Closes #74
Closes #68
